### PR TITLE
FCBHDBP-515 enable non-integer verse identifier - sofria

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,14 @@ The above test should create 200 .json files
 ls -1 output/ENGNKJO1ET-json/ |  wc -l
 ```
 
+# unit tests
+```shell
+node tests/gqlquery_verses_by_usx.test.js
+```
+
 # test verses
 
+## Case 1
 ```shell
 # clean JSON output folder:
 rm -rf output/Akawaio_N2AKEBSS_USX-json/*.*
@@ -140,6 +146,51 @@ The above test should create 28 .json files as well
 
 ```shell
 ls -1 output/Akawaio_N2AKEBSS_USX-json/ |  wc -l
+```
+
+## Case 2
+
+```shell
+# clean JSON output folder:
+rm -rf output/TXQWYIN_ET-json/*.*
+```
+
+```shell
+# clean output folder:
+rm -rf ./output/TXQWYIN1ET-db
+```
+
+```shell
+# create output folder:
+mkdir ./output/TXQWYIN1ET-db
+```
+
+```shell
+# create db file:
+touch ./output/TXQWYIN1ET-db/TXQWYIN1ET.db
+```
+
+```shell
+node biblebrain_uploader.js run test/input/TXQWYIN1ET/ --populate-db=./output/TXQWYIN1ET-db/TXQWYIN_ET.db --generate-json=./output/TXQWYIN_ET-json
+```
+
+- Outcome
+
+```shell
+Generate JSON => Generate JSON filese - Start process..
+Populate DB - Start process..
+Populate DB => Complete:  Markus
+Populate DB => success
+Generate JSON => File list (1) processing completed
+Generate JSON => Complete USX File: test/input/TXQWYIN1ET/041MRK.usx
+load verses success, rowcount 634
+load tableContents success, rowcount 1
+```
+
+The above test should create 16 .json files as well
+
+```shell
+ls -1 output/TXQWYIN_ET-json/ |  wc -l
 ```
 
 # Recommendations

--- a/gqlquery_verses_by_usx.js
+++ b/gqlquery_verses_by_usx.js
@@ -48,22 +48,25 @@ const generateJsonContentByUSXFile = async function (usxFile) {
 
       return {
         chapter: ci.chapter,
-        verses: ci.verses.reduce(
-          (result, verse) =>
-            verse.verse.length > 0 &&
-            !hashIdVerseRange.has(
-              `${ci.chapter}${bookCode}${verse.verse[0].verseRange}`
-            )
-              ? hashIdVerseRange.set(
-                  `${ci.chapter}${bookCode}${verse.verse[0].verseRange}`
-                ) &&
-                result.concat({
-                  verseRange: verse.verse[0].verseRange,
-                  text: verse.verse[0].text,
-                })
-              : result,
-          []
-        ),
+        verses: ci.verses.reduce((result, verse) => {
+          verse.verse.forEach((verseContent) => {
+            if (
+              !hashIdVerseRange.has(
+                `${ci.chapter}${bookCode}${verseContent.verseRange}`
+              )
+            ) {
+              hashIdVerseRange.set(
+                `${ci.chapter}${bookCode}${verseContent.verseRange}`
+              );
+              result = result.concat({
+                verseRange: verseContent.verseRange,
+                text: verseContent.text,
+              });
+            }
+          });
+
+          return result;
+        }, []),
       };
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "yargs": "^17.6.2"
       },
       "devDependencies": {
-        "prettier": "2.8.0",
-        "tape": "5.6.1"
+        "prettier": "2.8.3",
+        "tape": "5.6.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1888,16 +1888,18 @@
       "integrity": "sha512-5hHGjeggREJDKWBvxVv5RPKtcgKpraHAPu4DcvUcP8usgmK93UzL9oOPsV3h6VCrD2+wmgq0kHha2rnXZHAV3A=="
     },
     "node_modules/deep-equal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.1.0.tgz",
-      "integrity": "sha512-2pxgvWu3Alv1PoWEyVg7HS8YhGlUFUV7N5oOvfL6d+7xAmLSemMwv/c8Zv/i9KFzxV5Kt5CAvQc70fLwVuf4UA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
+      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-get-iterator": "^1.1.2",
         "get-intrinsic": "^1.1.3",
         "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.1",
         "is-date-object": "^1.0.5",
         "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
         "isarray": "^2.0.5",
         "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
@@ -1906,7 +1908,7 @@
         "side-channel": "^1.0.4",
         "which-boxed-primitive": "^1.0.2",
         "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.8"
+        "which-typed-array": "^1.1.9"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2158,6 +2160,7 @@
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
       "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -2219,6 +2222,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -2802,6 +2806,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
       "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -2884,6 +2889,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
       "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -2958,6 +2964,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -3240,6 +3257,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -3265,6 +3283,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3408,6 +3439,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3501,14 +3533,14 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
-      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       },
       "engines": {
@@ -3530,6 +3562,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -3650,9 +3683,9 @@
       "peer": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -4389,9 +4422,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4654,9 +4687,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -5074,6 +5107,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
       "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -5370,6 +5404,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
       "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -5383,6 +5418,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
       "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -5447,15 +5483,15 @@
       }
     },
     "node_modules/tape": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-5.6.1.tgz",
-      "integrity": "sha512-reNzS3rzsJtKk0f+zJx2XlzIsjJXlIcOIrIxk5shHAG/DzW3BKyMg8UfN79oluYlcWo4lIt56ahLqwgpRT4idg==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-5.6.3.tgz",
+      "integrity": "sha512-cUDDGSbyoSIpdUAqbqLI/r7i/S4BHuCB9M5j7E/LrLs/x/i4zeAJ798aqo+FGo+kr9seBZwr8AkZW6rjceyAMQ==",
       "dev": true,
       "dependencies": {
-        "array.prototype.every": "^1.1.3",
+        "array.prototype.every": "^1.1.4",
         "call-bind": "^1.0.2",
-        "deep-equal": "^2.0.5",
-        "defined": "^1.0.0",
+        "deep-equal": "^2.2.0",
+        "defined": "^1.0.1",
         "dotignore": "^0.1.2",
         "for-each": "^0.3.3",
         "get-package-type": "^0.1.0",
@@ -5464,14 +5500,14 @@
         "has-dynamic-import": "^2.0.1",
         "inherits": "^2.0.4",
         "is-regex": "^1.1.4",
-        "minimist": "^1.2.6",
-        "object-inspect": "^1.12.2",
+        "minimist": "^1.2.7",
+        "object-inspect": "^1.12.3",
         "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
-        "resolve": "^2.0.0-next.3",
+        "resolve": "^2.0.0-next.4",
         "resumer": "^0.0.0",
-        "string.prototype.trim": "^1.2.6",
+        "string.prototype.trim": "^1.2.7",
         "through": "^2.3.8"
       },
       "bin": {
@@ -5696,6 +5732,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -6021,16 +6058,16 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
-      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
+        "is-typed-array": "^1.1.10"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7679,16 +7716,18 @@
       "integrity": "sha512-5hHGjeggREJDKWBvxVv5RPKtcgKpraHAPu4DcvUcP8usgmK93UzL9oOPsV3h6VCrD2+wmgq0kHha2rnXZHAV3A=="
     },
     "deep-equal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.1.0.tgz",
-      "integrity": "sha512-2pxgvWu3Alv1PoWEyVg7HS8YhGlUFUV7N5oOvfL6d+7xAmLSemMwv/c8Zv/i9KFzxV5Kt5CAvQc70fLwVuf4UA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
+      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-get-iterator": "^1.1.2",
         "get-intrinsic": "^1.1.3",
         "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.1",
         "is-date-object": "^1.0.5",
         "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
         "isarray": "^2.0.5",
         "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
@@ -7697,7 +7736,7 @@
         "side-channel": "^1.0.4",
         "which-boxed-primitive": "^1.0.2",
         "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.8"
+        "which-typed-array": "^1.1.9"
       }
     },
     "deep-is": {
@@ -7916,6 +7955,7 @@
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
       "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -7968,6 +8008,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -8408,6 +8449,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
       "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -8466,6 +8508,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
       "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -8516,6 +8559,14 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "graceful-fs": {
@@ -8727,6 +8778,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -8746,6 +8798,16 @@
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
       }
     },
     "is-bigint": {
@@ -8837,7 +8899,8 @@
     "is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -8892,14 +8955,14 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
-      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       }
     },
@@ -8912,6 +8975,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -9007,9 +9071,9 @@
       "peer": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -9615,9 +9679,9 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
     },
     "object-is": {
       "version": "1.1.5",
@@ -9814,9 +9878,9 @@
       "peer": true
     },
     "prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
       "dev": true
     },
     "process": {
@@ -10122,6 +10186,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
       "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -10350,6 +10415,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
       "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -10360,6 +10426,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
       "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -10400,15 +10467,15 @@
       "peer": true
     },
     "tape": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-5.6.1.tgz",
-      "integrity": "sha512-reNzS3rzsJtKk0f+zJx2XlzIsjJXlIcOIrIxk5shHAG/DzW3BKyMg8UfN79oluYlcWo4lIt56ahLqwgpRT4idg==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-5.6.3.tgz",
+      "integrity": "sha512-cUDDGSbyoSIpdUAqbqLI/r7i/S4BHuCB9M5j7E/LrLs/x/i4zeAJ798aqo+FGo+kr9seBZwr8AkZW6rjceyAMQ==",
       "dev": true,
       "requires": {
-        "array.prototype.every": "^1.1.3",
+        "array.prototype.every": "^1.1.4",
         "call-bind": "^1.0.2",
-        "deep-equal": "^2.0.5",
-        "defined": "^1.0.0",
+        "deep-equal": "^2.2.0",
+        "defined": "^1.0.1",
         "dotignore": "^0.1.2",
         "for-each": "^0.3.3",
         "get-package-type": "^0.1.0",
@@ -10417,14 +10484,14 @@
         "has-dynamic-import": "^2.0.1",
         "inherits": "^2.0.4",
         "is-regex": "^1.1.4",
-        "minimist": "^1.2.6",
-        "object-inspect": "^1.12.2",
+        "minimist": "^1.2.7",
+        "object-inspect": "^1.12.3",
         "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
-        "resolve": "^2.0.0-next.3",
+        "resolve": "^2.0.0-next.4",
         "resumer": "^0.0.0",
-        "string.prototype.trim": "^1.2.6",
+        "string.prototype.trim": "^1.2.7",
         "through": "^2.3.8"
       },
       "dependencies": {
@@ -10578,6 +10645,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -10844,16 +10912,16 @@
       }
     },
     "which-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
-      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
+        "is-typed-array": "^1.1.10"
       }
     },
     "wide-align": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "yargs": "^17.6.2"
   },
   "devDependencies": {
-    "prettier": "2.8.0",
-    "tape": "5.6.1"
+    "prettier": "2.8.3",
+    "tape": "5.6.3"
   }
 }

--- a/test/input/TXQWYIN1ET/041MRK.usx
+++ b/test/input/TXQWYIN1ET/041MRK.usx
@@ -1,0 +1,1076 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<usx version="2.5">
+  <book code="MRK" style="id" />
+  <para style="h">Markus</para>
+  <para style="toc1">Lamatuak Yesus Tutui Malolen tungga Markus</para>
+  <para style="toc2">Markus</para>
+  <para style="toc3">Mrk</para>
+  <para style="mt2">Lamatuak Yesus Tutui Malolen</para>
+  <para style="mt2">tungga</para>
+  <para style="mt1">Markus</para>
+  <chapter number="1" style="c" />
+  <para style="s1">Yohanis Mana Sarani buka dalak fee Lamatuak Yesus</para>
+  <para style="r">(Mateos 3:1-12; Lukas 3:1-18; Yohanis 1:19-28)</para>
+  <para style="p">
+    <verse number="1" style="v" />Ia tutui malole, fo Manetualain Anan<note caller="+" style="f"><char style="fr" closed="false">1:1:</char><char style="ft" closed="false">Nai susura makasososan ketuk kara ta surak rae, “Manetualain Anan”.</char></note> tutuin. Ndia naden Yesus Karistus. Manetualain dudu elan numa lele uluk mai ena. Ndia tutuin mulai talo ia: <verse number="2" style="v" />Yesus bei ta mulai Ndia ue-osan, te Manetualain nadenu hatahori esa, nade Yohanis, fo nakahuluk buka dalak soa-neu Yesus mamain. Lele uluk Manetualain pake Ndia mana toꞌu dedeꞌan esa ena, nade baꞌi Yesaya. Ana surak memak kana ena nae:</para>
+  <para style="q1">“Nenene, ee! Au adenu Au hatahoring esa fo neu buka dalak fee O.<note caller="+" style="x"><char style="xo" closed="false">1:2:</char><char style="xt" closed="false">Maleaki 3:1</char></note></para>
+  <para style="q1">
+    <verse number="3" style="v" />Hatahori naa neu ko neni mamana nees neu, de ana bolu nae,</para>
+  <para style="q2">‘Basa hatahorir lalaꞌen tao malole dalak kara, fo simbok Lamatuak mamain!</para>
+  <para style="q2">Ma fua matetu dokek kara fo simbok kana.’ ”<note caller="+" style="x"><char style="xo" closed="false">1:3:</char><char style="xt" closed="false">Yesaya 40:3</char></note></para>
+  <para style="p">
+    <verse number="4-6" style="v" />Hatahorir roke rateme Yohanis rae Mana Saranik. Ana leo nai mamana nees. Bualoꞌa-papaken, ara taon numa banda onta bulun mai. Kalekeen numa banda roun mai. Nanaꞌa-nininun ndia lamak ma fani oe. [Yohanis leleo-lalaꞌon ia, sama leo baꞌi Elia lele uluk.]<note caller="+" style="x"><char style="xo" closed="false">1:4-6:</char><char style="xt" closed="false">2 Mane-manek kara 1:8</char></note></para>
+  <para style="p">Lelek naa, hatahorir ruma kota Yerusalem ma profensi Yudea isin nara mai ratonggo ro Yohanis numa ndia mamanan naa. Ara mai fo rae rita Yohanis ma sangga ramanene Yohanis nenorin. Yohanis nafada sara nae, “Ei muste manaku ma laꞌo ela basa ei sala-singgom mara lalaꞌen, fo ela Manetualain koka heni ei sala-singgom mara. Boe ma ei muste sarani dei, fo dadi neu tanda nae ei malole fali mia Manetualain ena.”</para>
+  <para style="p">Ramanene talo naa, boe ma ara manaku sala-singgon nara, de ana sarani sara numa lee Yarden.</para>
+  <para style="p">
+    <verse number="7" style="v" />Ana nafada nae, “Neu ko Hatahori moꞌo-inahuuk esa lena heni au bali nae mai. Leo mae dadi uu kada ndia ana neondan oo, au ta andaa boe.<note caller="+" style="f"><char style="fr" closed="false">1:7:</char><char style="ft" closed="false">Dedeꞌa Yunani huuk nae, “Aloe au aong fo sefi kada tali sopatun oo, au ta andaa boe.” Sosoa-ndandaan nae, Yohanis kada hatahori kadiꞌik, de mae dadi neu Lamatuak Yesus hatahori neondan oo, ndia ta nandaa boe.</char></note> <verse number="8" style="v" />Au sarani ei pake kada oe, tehuu neu ko Ana tao lena heni au, ma Ana tao nasofe ei dalem mara no Manetualain Dula-dale Malalaon.”</para>
+  <para style="s1">Yohanis sarani Lamatuak Yesus</para>
+  <para style="r">(Mateos 3:13-17; Lukas 3:21-22)</para>
+  <para style="p">
+    <verse number="9" style="v" />Neu faik naa, Yesus numa nggoro Nasaret manai profensi Galilea mai, mai natonggo no Yohanis. Boe ma Yohanis sarani Yesus numa lee Yarden. <verse number="10" style="v" />Yesus bei fo kalua numa oe dale mai, medak neu ma nita lalai natahuka, boe ma Manetualain Dula-dalen sama leo mbui lunda sina konda neni Yesus neu. <verse number="11" style="v" />Boe ma Manetualain nahara numa lalai mai nae,</para>
+  <para style="q1">“O ia, Au Ana susueng.</para>
+  <para style="q2">O soa tao mamahoko Au.”<note caller="+" style="x"><char style="xo" closed="false">1:11:</char><char style="xt" closed="false">Tutui Makasososak 22:2; Sosoda Kokoa-kikiok kara 2:7; Yesaya 42:1; Mateos 3:17; 12:18; Markus 9:7; Lukas 3:22</char></note></para>
+  <para style="s1">Nitur malanggan soba-dou Lamatuak Yesus numa mamana nees</para>
+  <para style="r">(Mateos 4:1-11; Lukas 4:1-13)</para>
+  <para style="p">
+    <verse number="12" style="v" />Basa boe ma Manetualain Dula-dalen nuni Yesus neni mamana nees esa neu. <verse number="13" style="v" />Nai mamanak naa, hambu kada banda fuir. Yesus leo numa naa doon faik haa hulu. Numa mamanak naa, nitur malanggan neu soba-dou Yesus fo tunggan, tehuu ta nala sana. Basa boe ma Manetualain atan nara ruma nusa tetuk do inggu temak mai fo reu ralalaun.</para>
+  <para style="s1">Lamatuak Yesus neni Galilea neu fo tui-bengga Manetualain Hara Lii Malolen</para>
+  <para style="r">(Mateos 4:12-17; Lukas 4:14-15)</para>
+  <para style="p">
+    <verse number="14" style="v" />Faik naa fo ara tao Yohanis neni bui dale neu, boe ma Yesus neni profensi Galilea neu tui-bengga Manetualain Hara Lii Malolen nai naa. <verse number="15" style="v" />Ana nafada nae,</para>
+  <para style="q1">“Nenene, ee! Hatematak ia Manetualain fain losa ena!</para>
+  <para style="q2">Hatematak ia basa hatahori bei fo bubuluk rae, Manetualain toꞌu parenda.</para>
+  <para style="q2">Huu naa de ei muste hahae numa ei pepeko-lelekom mai leo,</para>
+  <para style="q3">fo tungga falik Manetualain,</para>
+  <para style="q3">ma mamahere neu Ndia Hara Lii Malolen ia leo.”<note caller="+" style="x"><char style="xo" closed="false">1:15:</char><char style="xt" closed="false">Mateos 3:2</char></note></para>
+  <para style="s1">Lamatuak Yesus nanggou mana puꞌa-dala fo tunggan</para>
+  <para style="r">(Mateos 4:18-22; Lukas 5:1-11)</para>
+  <para style="p">
+    <verse number="16" style="v" />Faik esa, Yesus laꞌok tungga dano Galilea tatain. Ana nita hatahori esa, nade Simon no fadin nade Anderias. Dua sara dala iꞌak. Naa sira ue-osan tungga-tungga faik. <verse number="17" style="v" />Yesus nanggou sara nae, “Woi! Mai fo tungga au leo! Ei masiꞌe sangga iꞌak, tehuu hatematak ia Au tao ei dadi miu mana sangga samanek.” <verse number="18" style="v" />Dua sara ramanene rala naa, boe ma ara laꞌo ela dala naa, fo reu tungga Yesus tutik ka.</para>
+  <para style="p">
+    <verse number="19" style="v" />Basa de Yesus laꞌok nala faa bali, boe ma nita Sabadius anan nara. Kaꞌak nade Yakobis no fadin nade Yohanis. Dua sara rafafaꞌu ralole puꞌak nai ofak lain. <verse number="20" style="v" />Yesus nanggou dua sara nae, “Wee! Mai fo tungga Au!” Boe ma dua sara laꞌo ela sira aman ma hatahori manaꞌa nggadin nara rai ofak lain. De ara reu tungga Yesus.</para>
+  <para style="s1">Lamatuak Yesus husi kalua heni nitu numa hatahori esa mai numa kota Kapernaum</para>
+  <para style="r">(Lukas 4:31-37)</para>
+  <para style="p">
+    <verse number="21" style="v" />Basa boe ma Yesus no hatahori kahaak kara fo mana tungga Ndia naa, losa kota Kapernaum. Faik naa ndaa no hatahori Yahudir fai huhule-haradoin,<note caller="+" style="f"><char style="fr" closed="false">1:21:</char><char style="ft" closed="false">Hatahori Yahudi fai huhule-haradoin, fai hahae aok, do, fai hahae tao ue-osa, ara rae, ‘Fai Sabat.’</char></note> boe ma Yesus maso neni uma huhule-haradoik dale neu, de fee nenorik numa naa. <verse number="22" style="v" />Basa hatahori heran bali-bali neu ramanene Ndia kokolan, huu Ana bubuluk no tetuk nenorik naa isin. Naa, ta sama no hatahori Yahudi meser anggaman nara.<note caller="+" style="x"><char style="xo" closed="false">1:22:</char><char style="xt" closed="false">Mateos 7:28-29</char></note></para>
+  <para style="p">
+    <verse number="23" style="v" />Faik naa, hambu hatahori fo nitu saꞌek esa. Ana oo neni uma huhule-haradoik dale neu, boe ma nitu manai hatahori naa dale bolu <verse number="24" style="v" />nae, “Weeh! Yesus hatahori Nasaret! O mai tao hata mua ai nai ia! O mai sangga makalulutu ai, hetu? Ai malela O. O ia, Hatahori Malalaok fo lele uluk Manetualain helu-bartaa nae nadenun mai.”</para>
+  <para style="p">
+    <verse number="25" style="v" />Yesus mbokan nae, “Makatema o bafam! Kalua laꞌo ela hatahori naa!”</para>
+  <para style="p">
+    <verse number="26" style="v" />Boe ma nitu naa tao nala hatahori naa ao-inan leꞌa kede-kede. De ana kalua numa hatahori naa neu, ma nakau nahere. <verse number="27" style="v" />Boe ma basa hatahori manai uma huhule-haradoik naa dale bafan nara bese mboo, de rakokola aok rae, “Awii! Ia hata ia? Ana parenda nitur, de ara kalua tungga Ndia hihiin. Ia nenori beuk, do? Tou lasik kokolan ta neni babanggak!”</para>
+  <para style="p">
+    <verse number="28" style="v" />Boe ma hatahorir mulai tui-bengga mandadik naa ndule nggorok kara marai profensi Galilea.</para>
+  <para style="s1">Lamatuak Yesus tao nahai Petrus ari-inan no hatahori noꞌuk kara</para>
+  <para style="r">(Mateos 8:14-17; Lukas 4:38-41)</para>
+  <para style="p">
+    <verse number="29" style="v" />Ara kalua numa uma huhule-haradoik naa dale mai, boe ma Yesus neni Simon no Anderias uman neu. Yakobis no Yohanis tungga sara boe. <verse number="30" style="v" />Simon ari-inan sumai, de ana sunggu nai mamana susungguk lain. Neu Yesus no ana nunin nara bei fo maso reni uma naa reu, te hatahori mai rafadan rae, “Ina lasik hambu sumaik.”</para>
+  <para style="p">
+    <verse number="31" style="v" />Basa boe ma Yesus neu tiro ina lasik, de Ana toꞌu nala liman fo nadedein. Ina lasik hedin mopon tutik kana. Boe ma ana nambadeik, de neu nalalau sara.</para>
+  <para style="p">
+    <verse number="32" style="v" />Neu ledo dei fo nae tesa, hatahorir reni sira hatahori kamahedin nara ma sira hatahorin fo nitu saꞌek kara mai, fo hule Yesus tulu-fali sara. <verse number="33" style="v" />Losa basa hatahori kota esa isin nara rakarumbu reu de sofe uma naa bebelan. <verse number="34" style="v" />Hatahorir raa hedin nara mata-matak kara, tehuu Yesus tao nahai basa-basa sara. Ma Ana oo husi kalua heni nitu noꞌuk ka boe. Ana ta fee lelak nitur raa kokolak, te ara oo ralelan boe, na.</para>
+  <para style="s1">Lamatuak Yesus laꞌok ndule nggorok laen nara fo neu tui-bengga Manetualain Hara Lii Malolen</para>
+  <para style="r">(Lukas 4:42-44)</para>
+  <para style="p">
+    <verse number="35" style="v" />Neu beꞌe-mai dulu silu fo bei makiuk, Yesus beꞌe ena de laꞌo numa uma naa neu. Ana neni mamana nees esa neu fo Ana hule-haradoi, kola-kola no Manetualain. <verse number="36" style="v" />Neu Simon asa beꞌe, ta mete-rita Yesus de reu sanggan. <verse number="37" style="v" />Ara ratonggo ro Yesus, de rafadan rae, “Papa, hatahori noꞌuk ka mai sangga Papa.”</para>
+  <para style="p">
+    <verse number="38" style="v" />Boe ma Ana naselu nae, “Naa oo malole boe. Tehuu malole lenak ita teni nggorok laen mana deka nai ia teu dei. Au oo nau tui-bengga Hara Lii Malole neu sara boe. Te naa Au ue-osan, na.”</para>
+  <para style="p">
+    <verse number="39" style="v" />Basa boe ma Ana laꞌo ndule basa profensi Galilea fo tui-bengga Manetualain Hara Lii Malolen nai sira uma huhule-haradoin nara dale. Ma Ana oo husi heni basa nitur numa hatahorir mai boe.<note caller="+" style="x"><char style="xo" closed="false">1:39:</char><char style="xt" closed="false">Mateos 4:23; 9:35</char></note></para>
+  <para style="s1">Lamatuak Yesus tao nahai hatahori hedi kusta esa</para>
+  <para style="r">(Mateos 8:1-4; Lukas 5:12-16)</para>
+  <para style="p">
+    <verse number="40" style="v" />Faik naa, hambu hatahori hedi kusta esa neni Yesus neu. Boe ma ana sendek luu-langgan de noke tulu-falik neu Yesus nae, “Papa, ee! Tulu-fali au dei! Au bubuluk Papa bisa tao mamopo au heding ia, mita fo hatahori boso nunute au bali. Sadi Papa nau.”</para>
+  <para style="p">
+    <verse number="41" style="v" />Basa boe ma Yesus dalen tuda kasian neu hatahori naa, de Ana loo liman fo nafaroe neun, ma nae, “Memak Au nau! O hai leo!” <verse number="42" style="v" />Medak neu ma, hatahori naa hedin mopon tutik ka. De ana hai leo. <verse number="43" style="v" />Boe ma Yesus nadenu hatahori naa fali neu ngga, ma Ana fee nesenedak neun <verse number="44" style="v" />nae, “Masaneda matalolole, o hai ena, tehuu ta bole tui esa boe na! Ma o muste tungga baꞌi Musa parendan dei. De muni malangga anggama muu dei, fo ana parisa o ao-inam, fo mete-nita o hedin mopon tebe ena, do beik. Boe ma muste muni o fefeem tanda makasi, mita fo basa hatahori bubuluk rae, o hai tebe-tebe ena.”<note caller="+" style="x"><char style="xo" closed="false">1:44:</char><char style="xt" closed="false">Malangga Anggamar Hohoro-lalanen 14:1-32</char></note></para>
+  <para style="p">
+    <verse number="45" style="v" />Tehuu hatahori naa kalua, boe ma ana tui ndule sudi nai bee. De hatahori noꞌuk ka sangga fo rae ratonggo ro Yesus, losa-losak Ana ta bisa natudu matan nai nggorok dale. Ana leo nai mamana nees nai kada nggorok dea. Tehuu hatahorir sudi lua ruma bee mai fo sangga ratonggo roon.</para>
+  <chapter number="2" style="c" />
+  <para style="s1">Lamatuak Yesus tao nahai hatahori keko-luꞌuk</para>
+  <para style="r">(Mateos 9:1-8; Lukas 5:17-26)</para>
+  <para style="p">
+    <verse number="1" style="v" />Tada faik hida boe ma Yesus neni Kapernaum neu seluk bali. Boe ma hatahorir ramanene rae Yesus nai uma ena. <verse number="2" style="v" />De hatahorir sudi ruma bee mai. Ara rakarumbu reu de rakaseseꞌe uma dale, ara sasi losa lelesu dea. Boe ma Yesus nafada sara Manetualain hihii-nanaun.</para>
+  <para style="p">
+    <verse number="3" style="v" />Yesus bei kola-kola, te hatahori haa ndoro reni hatahori keko-luꞌuk esa neni Yesus neu. <verse number="4" style="v" />Tehuu hatahori sofen seꞌe-seꞌe, huu naa de ta bisa reni hatahori naa losa Yesus matan. Boe ma ara hene reni uma lain reu, de ara ofe heni uma sinin nai Yesus ndandaan lain. Ara ofe heni uma sinin, boe ma rakonda hatahori keko-luꞌuk naa no neneꞌin dae neu.<note caller="+" style="f"><char style="fr" closed="false">2:4:</char><char style="ft" closed="false">Ara nane sira neneꞌin numa hata matea mai.</char></note> <verse number="5" style="v" />Neu Yesus mete-nita sara, Ana bubuluk ara ramahere tebe-tebe neu Ndia. Boe ma nafada hatahori keko-luꞌuk naa nae, “Ana nggee! Au fee ambon neu o sala-singgom mara ena!”</para>
+  <para style="p">
+    <verse number="6" style="v" />Hambu meser anggama Yahudi hida ranggatuuk ruma naa. Neu ara ramanene Yesus kokolan naa, boe ma rameda ta malole nai dalen nara. <verse number="7" style="v" />De rakokola aok rae, “Hatahori ia nambarani sudi selik kana kokolak nae leo naa, ee! Kada Manetualain mesa kana bisa fee ambon neu hatahori sala-singgon. Hatahori ia kokolan naa, nakasasamak aon sama leo Manetualain. Ana nakadadaek Manetualain naa ena, ma!”</para>
+  <para style="p">
+    <verse number="8" style="v" />Tehuu Yesus bubuluk memak dalen nara ena. De Ana nafada sara nae, “Ei boso duꞌa talo naa! <verse number="9-10" style="v" />Tungga ei hahambum, na, bee ndia dakuk? Mete ma Au afada hatahori keko-luꞌuk ia ae, ‘O sala-singgom hambu ambon ena,’ na, neu ko ei ta bubuluk ana dadi tebe talo naa, do taa. Tehuu mete ma Au ae, ‘Mambadeik leo! Lulu mala o neneꞌim fo fali muu ngga leo’. Mete ma ana nambadeik tutik kana, naa ei bei fo mete-mita no ei matam mara mae, Au ia Hatahori Dae-bafo Isi-isik. Au aena koasa ma haak fo fee ambon neu hatahori sala-singgon.”</para>
+  <para style="p">Basa boe ma Yesus nafada hatahori keko-luꞌuk naa nae, <verse number="11" style="v" />“O nenene, ee! Hatematak ia o hai ena! De mambadeik, lulu mala o neneꞌim fo fali muu ngga leo, ee.”</para>
+  <para style="p">
+    <verse number="12" style="v" />Ana namanene nala talo naa, boe ma nambadeik tutik kana. De ana lulu nala neneꞌin, boe ma ana kalua laꞌo. Basa hatahorir ruma naa mete-rita ro mata deꞌen. Boe ma basa sara bafa bese mboo, de rae, “Awii! Ita bei fo mete tita dedeꞌa leo iak! Manetualain memak ta neni babanggak!”</para>
+  <para style="s1">Lamatuak Yesus noke Lewi fo tungga Ndia</para>
+  <para style="r">(Mateos 9:9-13; Lukas 5:27-32)</para>
+  <para style="p">
+    <verse number="13" style="v" />Basa boe ma Yesus fali neni dano Galilea tatain neu bali. Hatahori noꞌuk ka mai ratonggo roon, boe ma Ana nafada sara Manetualain hihii-nanaun.</para>
+  <para style="p">
+    <verse number="14" style="v" />Numa naa, hambu hatahori esa nade Lewi, Alpius anan. Ana dadi neu man-parenda Roma mana susu bean. Yesus laꞌok nesik naa boe ma Ana mete-nita Lewi, de nae, “Wee! Mai fo tungga Au!”</para>
+  <para style="p">Lewi namanene nala Yesus nae leo naa, boe ma ana nambadeik fo tunggan tutik kana leo.</para>
+  <para style="p">
+    <verse number="15" style="v" />Basa boe ma Yesus asa raꞌa numa Lewi uman, sama-sama ro Lewi nonoo mana susu bean nara. Hambu hatahorir laen oo fo hatahori Yahudir henggenee sara rae, hatahori ta neulauk kara, tungga raꞌa ro sara numa naa boe. Numa hatahori mana ranggatuuk raꞌa naa mai, noꞌuk ka hii ramanene Yesus.</para>
+  <para style="p">
+    <verse number="16" style="v" />Faik naa, hambu meser anggama hida ruma partei Farisi mai, mete-rita Yesus nanggatuuk naꞌa no mana susu bear ma hatahori ta neulauk kara. Boe ma ratane ana nunin nara rae, “Tao hata de ei mesem nanggatuuk naꞌa no hatahori mana susu bear ma hatahori ta neulauk kara raa?”</para>
+  <para style="p">
+    <verse number="17" style="v" />Tehuu Yesus namanene ara ratatane aok talo naa, boe ma Ana naselu nae, “Hatahori kamahedik memak parluu doter, tehuu hatahori bee fo sodak ena ta parluu. Au mai fo alalau hatahori ta neulauk kara. Tehuu Au ta mai fo alalau hatahori fo mana nameda aon hatahori ndoos ena.”</para>
+  <para style="s1">Lamatuak Yesus nenori beun ta sama no hatahori Farisir nenorin</para>
+  <para style="r">(Mateos 9:14-17; Lukas 5:33-39)</para>
+  <para style="p">
+    <verse number="18" style="v" />Laꞌe esa, partei anggama Farisi hatahorin nara puasa tungga anggama hohoro-lalanen. Ara mete-rita Yohanis Mana Saranik ana nunin nara oo puasa boe. Tehuu ta mete-rita Yesus ana nunin nara puasa leo sira. Boe ma sira hatahorin nara mai ratonggo ro Yesus, de ratanen rae, “Papa. Ai puasa. Yohanis hatahorin nara oo puasa boe. Tehuu tao hata de Papa ana nunin nara ta puasa?”</para>
+  <para style="p">
+    <verse number="19" style="v" />Boe ma Yesus naselu nae, “Memak ei bubuluk ena, mete ma tao feta kabin, na, fuik kara ta puasa, tehuu raꞌa-rinu losa rakabete. Mete ma baroit touk bei nai naa, na, neu ko basa sara raꞌa-rinu rame-rame. <verse number="20" style="v" />Tehuu neu faik esa mete ma hatahorir humu reni baroit touk, na, nonoon nara rameda susa, dei fo ara puasa.”</para>
+  <para style="p">
+    <verse number="21" style="v" />Boe ma Yesus tamba lololek esa nae, “Hatahori ta tanda tema beuk neu badu raak. Te mete ma safen, na, tema beuk naa kukundu de ana tao nasida tamba seluk badu raak naa. <verse number="22" style="v" />Leo naak oo hatahori ta radai oe anggor beuk neni boboꞌik banda rou raak dale neu boe, te neu ko kadin ma ana sii sasarak, de oe anggor beuk naa mboꞌa henin. Dadi oe anggor beuk muste nadain neni boboꞌik banda rou beuk neu.”<note caller="+" style="f"><char style="fr" closed="false">2:22:</char><char style="ft" closed="false">Susura Malalaok dedeꞌa Yunani surak nae, “boso madai oe anggor beuk neni boboꞌik banda rou raak dale neu, fo boso losak ana fanggi do sidan.”</char></note> [No lololek naa, Yesus nanori sara nae Ndia nenori beun boso babalik kana no hatahori Farisir nenori raan.]</para>
+  <para style="s1">Lamatuak Yesus ana nunin nara ketu rala hade-nggandum ndaa no fai hahae tao ue-osa</para>
+  <para style="r">(Mateos 12:1-8; Lukas 6:1-5)</para>
+  <para style="p">
+    <verse number="23" style="v" />Laꞌe esa, ndaa no hatahori Yahudir fai huhule-haradoin, Yesus asa laꞌok resik osi esa dale. Boe ma Ndia ana nunin nara ketu rala hade-nggandum, de raꞌa.<note caller="+" style="x"><char style="xo" closed="false">2:23:</char><char style="xt" closed="false">Tui Seluk laꞌe-neu Dala Masodak 23:25</char></note> <verse number="24" style="v" />Tehuu hatahori Farisir mete-rita, de ratane Yesus rae, “Tao hata de O ana nunim mara lena-langga ita anggaman hohoro-lalanen? Ara ketu hade-nggandum ndaa no fai hahae tao ue-osa. Ei boso tao talo naa!”</para>
+  <para style="p">
+    <verse number="25-26" style="v" />Ana naselu nae, “Talo bee, ou? Ei ta masaneda baꞌi Dauk tutuin, do? Lelek naa Abiatar dadi neu malangga anggama Yahudir malangga ina-huun. Baꞌi Dauk no ana nunin nara taꞌin nara kada kikiok, nahuu ndoe ralan seli ena. De ara maso reni Manetualain Laa Huhule-haradoin dale reu, boe ma haꞌi rala roti fo malangga anggamar fee basan neu Manetualain ena, de ara raꞌa. Naa te kada malangga anggamar ndia raꞌa roti naa, tehuu hatahori laen ta bole. De baꞌi Dauk asa raꞌa, tehuu ta hambu hatahori esa boe na fee salak neu sara.”<note caller="+" style="x"><char style="xo" closed="false">2:25-26:</char><char style="xt" closed="false">1 Semuel 21:1-6; Malangga Anggamar Hohoro-lalanen 24:9</char></note></para>
+  <para style="p">
+    <verse number="27" style="v" />Boe ma Yesus nafada seluk bali nae, “Ei boso lilii-ndondou, huu Manetualain tao fai hahae tao ue-osa dadi neu babaꞌe-babatik fo tulu-fali ita hatahori dae-bafok. Ana ta tao ita hatahori dae-bafok fo kada tungga fai hahae tao ue-osa hohoro-lalanen. <verse number="28" style="v" />Au ia, Hatahori Dae-bafo Isi-isik. De Au ndia aena haak fo afada hatahori dae-bafok ae bole, do ta bole tao sudi hata ndaa no fai hahae tao ue-osa.”</para>
+  <chapter number="3" style="c" />
+  <para style="s1">Lamatuak Yesus tao nahai hatahori ndaa no fai hahae tao ue-osa</para>
+  <para style="r">(Mateos 12:9-14; Lukas 6:6-11)</para>
+  <para style="p">
+    <verse number="1" style="v" />Basa boe ma Yesus fali seluk neni uma huhule-haradoik neu. Numa naa, Ana mete-nita hatahori esa fo liman seri mates. <verse number="2" style="v" />Numa naa oo, hambu hatahori ruma ara sangga-sangga dalak fo fee salak neu Yesus boe. De ara mete mamakun fo sangga bubuluk Ana tao nahai hatahori naa ndaa no fai hahae tao ue-osa, do taa.</para>
+  <para style="p">
+    <verse number="3" style="v" />Boe ma Yesus nanggou hatahori fo lima mate seserik naa nae, “Mai fo mambariik muu mata ia.”</para>
+  <para style="p">
+    <verse number="4" style="v" />Boe ma Ana natane basa hatahorir raa nae, “Mete ma tungga ita anggaman hohoro-lalanen, ita bole tao kada hata ndaa no fai hahae tao ue-osa? Ita tao malole, do taa? Ita tao tahai hatahori, do tao tisan?” Tehuu basa sara bengge nee.</para>
+  <para style="p">
+    <verse number="5" style="v" />De Yesus dalen susa nalan seli, nahuu ara hii kada tao matak neu anggama hohoro-lalanen, tehuu ta mbali neu hatahori fo lima mate seserik naa. Boe ma Ana namanasa de nakabubulak matan mbali sara. Basa de Ana nafada hatahori naa nae, “Loo o limam mai leo!” Hatahori naa loo liman neu, boe ma medak neu te liman hai tutik ka.</para>
+  <para style="p">
+    <verse number="6" style="v" />Basa boe ma hatahori Farisir raa laꞌo ela uma huhule-haradoik naa. De ara reu rala harak esa ro Herodes partei politin hatahorin nara fo ara sangga dalak rae tao risa Yesus.</para>
+  <para style="s1">Lamatuak Yesus tao nahai hatahori noꞌuk ka numa dano tatain</para>
+  <para style="p">
+    <verse number="7-8" style="v" />Laꞌe esa, Yesus no ana nunin nara rakadedeak reni dano Galilea tatain reu. Tehuu hatahori noꞌuk ka ramanene basa hata fo Ana taon ena, huu naa de ara ruma basa nggorok kara mai fo tunggan. Ara ruma profensi Galilea, profensi Yudea ma profensi Idumea mai. Hambu ketuk ruma kota Yerusalem, kota Sidon ma kota Tirus mai. Ketuk bali ruma lee Yarden boboan dulu mai. Basa sara sangga Yesus fo rae ratonggo roon. <verse number="9" style="v" />Huu hatahori noꞌun seli de Yesus nadenu ana nunin nara sadia feen ofak esa. Yesus hii kokolak numa ofak lain mai, mita fo basa sara ramanene ma mete-ritan no malole.</para>
+  <para style="p">
+    <verse number="10" style="v" />Fai bakahulun Ana tao nahai nita hatahori hedis noꞌuk ka. Huu naa de hatematak ia basa hatahori kamahedik kara rakaseseti fo nau rafaroe Yesus.<note caller="+" style="x"><char style="xo" closed="false">3:10:</char><char style="xt" closed="false">Markus 4:1; Lukas 5:1-3</char></note> <verse number="11" style="v" />Neu hatahori fo nitu saꞌek kara mete-rita Yesus, boe ma lenggu heni sara ma rakaluku neu Yesus losa matan nara laꞌe daer. De ara bolu rahere rae, “O ia, memak Manetualain Anan!”</para>
+  <para style="p">
+    <verse number="12" style="v" />Tehuu Ana kaꞌi nahere sara nae, “Boso mafada hatahori esa boe na mae, Au ia see!”</para>
+  <para style="s1">Lamatuak Yesus here hatahori salahunu dua dadi neu Ndia ana nunin nara</para>
+  <para style="r">(Mateos 10:1-4; Lukas 6:12-16)</para>
+  <para style="p">
+    <verse number="13" style="v" />Basa boe ma Yesus hene neni letek esa lain neu. Ana nanggou nala hatahori ruma fo ndaa no Ndia dalen. De ara reu ratonggo roon. <verse number="14" style="v" />Boe ma Ana here nala hatahori salahunu dua. De Ana nafada sara nae, “Au here ei fo tungga Au seku neu, fo dadi miu Au nedenung. Au fee ei miu tui-bengga Manetualain hara hehelun neu basa hatahori lalaꞌen. <verse number="15" style="v" />Ma Au ae baꞌe fee ei koasa, fo ei bisa husi heni nitur ruma hatahorir mai.”</para>
+  <para style="p">
+    <verse number="16-19" style="v" />Hatahori kasalahunu duak kara raa naden, sira:</para>
+  <para style="q2">Simon (Yesus foin nade Petrus boe),</para>
+  <para style="q2">Yakobis,</para>
+  <para style="q2">Yohanis (Yakobis no fadin Yohanis ia, dua sara, Sabadius anan. Yesus foi dua sara nade ‘Boanerges’, sosoa-ndandaan nae ‘sama leo lalai nakaruu’.)<note caller="+" style="f"><char style="fr" closed="false">3:16-19</char><char style="ft" closed="false">a: Susura dedeꞌa Yunani nae, ‘mana masaparak anan’, sosoa-ndandaan nae, ‘nok bali lalai nasaparak ia’ Hatahori malelak ketuk duꞌa rae, Yakobis no Yohanis haran nara rakaruu te ara hii rasaparak sama leo lalai nakaruu ia.</char></note></para>
+  <para style="q2">Anderias,</para>
+  <para style="q2">Felipus,</para>
+  <para style="q2">Bartolomeos,</para>
+  <para style="q2">Mateos,</para>
+  <para style="q2">Tomas,</para>
+  <para style="q2">Yakobis (Alpius anan),</para>
+  <para style="q2">Tadius,</para>
+  <para style="q2">Simon (mana tungga partei politik Selot),<note caller="+" style="f"><char style="fr" closed="false">3:16-19</char><char style="ft" closed="false">b: Partei Selot ia, ara sangga dalak fo rakamboꞌik numa Roma parenda-koasan mai. Ara oo foi partei ia nade, ‘Patriot’ boe.</char></note></para>
+  <para style="q2">ma Yudas Iskariot (ana ia ndia neu ko seꞌo heni Yesus).</para>
+  <para style="s1">Meser anggamar fee salak neu Lamatuak Yesus rae, nitur malanggan ndia feen koasa</para>
+  <para style="r">(Mateos 12:22-32; Lukas 11:14-23; 12:10)</para>
+  <para style="p">
+    <verse number="20" style="v" />Basa boe ma Yesus no ana nunin nara konda fali numa letek lain mai. De ara maso reni uma dale reu. Tehuu hatahori noꞌuk ka mai rakarumbu rala Yesus bali, losa ara ta hambu lelak fo raꞌa-rinu. <verse number="21" style="v" />Hatahori mete-rita talo naa, boe ma rae, “Hena mete neu Yesus dei. Ana lilii faduli ao-inan ena.” Nufanelun nara ramanene hatahori kokolak talo naa, boe ma ara mai rae nuni roon laꞌo.</para>
+  <para style="p">
+    <verse number="22" style="v" />Faik naa, meser anggamar ruma Yerusalem mai fo rafada hatahori marai naa rae, “Weeh! Ei boso tungga doꞌo-doꞌo mia Yesus naa. Te Ana bisa husi nitu talo naa, nahuu Ana hambu koasa numa nitur malanggan mai, fo hatahori rasiꞌe roken rae, Balsebul.”<note caller="+" style="x"><char style="xo" closed="false">3:22:</char><char style="xt" closed="false">Mateos 9:34; 10:25</char></note></para>
+  <para style="p">
+    <verse number="23" style="v" />Yesus namanene nala naa, boe ma ana noke nala basa sara, de nafada nae, “Ta dadi leo naak! Nitur malanggan ta bisa husi nasafali aon. <verse number="24" style="v" />Mete ma nai nusak esa dale rau-inggun nara rahuur-ratofa, na, neu ko nusak naa ta bisa nakataka nala dook. <verse number="25" style="v" />Mete ma uma-loo esa isin nara kada raraꞌu ao, na, neu ko uma-loo naa tetu-teman taa. <verse number="26" style="v" />Leo naak oo mete ma nitur esa musu no esa boe, na, ndara baꞌe sara. No dalak naa, ara sida rakalulutu.</para>
+  <para style="p">
+    <verse number="27" style="v" />Mete ma naꞌo manu-meo nae mai foꞌai bua-baꞌu nai hatahori barakaik esa uman, na, ana muste humu nala hatahori naa, boe ma futu-paꞌan dei. Basa dei fo ana bisa foꞌai uma naa bua-baꞌun.<note caller="+" style="f"><char style="fr" closed="false">3:27:</char><char style="ft" closed="false">No dalak naa, Yesus nafada nae, Ndia koasan lena heni nitur malanggan, fo rasiꞌe roken rae, ‘Balsebul’.</char></note></para>
+  <para style="p">
+    <verse number="28" style="v" />Dadi Au afada memak ei: Manetualain sadia koka heni hatahori sala-singgon. Mete ma hatahori kokolak nakadadaek hatahori laen, na, Manetualain bei sadia fee ambon neun. <verse number="29" style="v" />Tehuu mete ma hatahori nambarani kokolak nakadadaek Manetualain Dula-dale Malalaon, na, Manetualain ta fee ambon neun, losa dae-bafok fai mateꞌen boe!”<note caller="+" style="x"><char style="xo" closed="false">3:29:</char><char style="xt" closed="false">Lukas 12:10</char></note></para>
+  <para style="p">
+    <verse number="30" style="v" />Yesus kokolak talo naa, nahuu ara henggeneen rae, “Hatahori naa, nitu saꞌen ena!”</para>
+  <para style="s1">Hatahori mana tungga Manetualain hihii-nanaun, sira ndia Lamatuak Yesus nufanelun tebe-teben</para>
+  <para style="r">(Mateos 12:46-50; Lukas 8:19-21)</para>
+  <para style="p">
+    <verse number="31" style="v" />Basa boe ma Yesus inan ma fadin nara reni uma naa reu, fo sangga ratonggo roon. Ara losa boe ma rambariik kada dea, de ara fee hatahori neu noken. <verse number="32" style="v" />Faik naa, Yesus nanggatuuk kola-kola no hatahori noꞌuk ka. Boe ma hatahori mai nafadan nae, “Papa, ee! Papa mamam ma fadim mara rai dea. Ara sangga ratonggo ro Papa.”</para>
+  <para style="p">
+    <verse number="33" style="v" />Tehuu Yesus naselu nae, “Au mamang ma toranoong tebe-teben, sira seer?”</para>
+  <para style="p">
+    <verse number="34" style="v" />Boe ma Ana mete basa hatahori mana manggatuu eko-feon. De Ana nae, “Basa ei lalaꞌen ia ndia Au mamang ma toranoong tebe-teben. <verse number="35" style="v" />See ndia tungga Manetualain hihii-nanaun, na, ana ndia Au nufanelu tebe-tebeng.”</para>
+  <chapter number="4" style="c" />
+  <para style="s1">Lamatuak Yesus fee lololek laꞌe-neu hatahori nggari bini-nggees nai dae mata-matak kara</para>
+  <para style="r">(Mateos 13:1-9; Lukas 8:4-8)</para>
+  <para style="p">
+    <verse number="1" style="v" />Laꞌe esa, Yesus neni dano Galilea neu bali. Boe ma hatahori noꞌuk ka mai rakarumbu ralan. De Ana hene neu nanggatuuk numa ofa mana seek esa numa naa lain, boe ma Ana fee nenorik. Basa hatahori marai mada lai nenene nenorin.<note caller="+" style="x"><char style="xo" closed="false">4:1:</char><char style="xt" closed="false">Lukas 5:1-3</char></note> <verse number="2" style="v" />De Ana fee nenorik noꞌuk ka neu sara pake lololek nae,</para>
+  <para style="p">
+    <verse number="3" style="v" />“Ei nenene matalolole, ee! Hambu hatahori esa neu nggari bini-nggees nai ndia osin dale. <verse number="4" style="v" />Neu ana nggari bini-nggees sara raa, hambu ketuk tuda nai dalak. Boe ma mbuik kara mai, de bido rabasa sara. <verse number="5" style="v" />Ma bini-nggees ketuk tuda ndaa dae batuk. Bini-nggees sara raa ranumbu lai-lai, tehuu dae niꞌis, <verse number="6" style="v" />de neu ledo hene mai lain de nahaa, boe ma numbun nara male de mate ramatuu. Te okan nara ta tora losa dae dale na.</para>
+  <para style="p">
+    <verse number="7" style="v" />Bini-nggees ketuk bali tuda nai dila-nggauk taladan. Boe ma dila-nggauk seti rakamate numbun nara, de ta bisa raboa. <verse number="8" style="v" />Ma bini-nggees ketuk bali tuda ndaa dae isik. Bini-nggees sara raa ranumbu, basa de ramoꞌo losa raboa. Ketuk fee falik buna-boak lipa laꞌe telu hulu, ketuk lipa laꞌe nee hulu, ma hambu ketuk bali losa lipa laꞌe natun esa.</para>
+  <para style="p">
+    <verse number="9" style="v" />Dadi ei see ndia kandiꞌi dook, na, nenene matalolole, ee!”</para>
+  <para style="s1">Tao hata de Lamatuak Yesus kokolak pake lololek</para>
+  <para style="r">(Mateos 13:10-17; Lukas 8:9-10)</para>
+  <para style="p">
+    <verse number="10" style="v" />Boe ma neu Yesus mesa kana, Ndia ana nuni kasalahunu duan nara ma hatahori laen ruma fo mana ramanene rita Ndia nenorin naa, ara mai ratonggo roon. Ara roken nafada lololek naa sosoa-ndandaan. <verse number="11" style="v" />Boe ma Yesus naselu nae, “Huu ei nau bubuluk tebe-tebe Manetualain parendan, de Au afada memak lololek naa sosoa-ndandaan. Tehuu mete ma hatahori laen, na, Au anori no kada lololek. <verse number="12" style="v" />Hatahori laen nara sama leo hata fo Manetualain mana toꞌu dedeꞌan surak memak kana ena nae,</para>
+  <para style="q1">‘Ara mete-rita ena, tehuu ta nau ralela.</para>
+  <para style="q2">Ara ramanene ena, tehuu ta nau bubuluk.</para>
+  <para style="q1">Naa fo ara hae ramahere neu Manetualain,</para>
+  <para style="q2">fo Manetualain ta parluu fee ambon neu sara bali.’ ”<note caller="+" style="x"><char style="xo" closed="false">4:12:</char><char style="xt" closed="false">Yesaya 6:9-10</char></note></para>
+  <para style="s1">Lamatuak Yesus nafada lololek bini-nggees naa sosoa-ndandaan</para>
+  <para style="r">(Mateos 13:18-23; Lukas 8:11-15)</para>
+  <para style="p">
+    <verse number="13" style="v" />Basa boe ma Yesus nafada sara lololek naa sosoa-ndandaan nae, “Mete ma ei bei ta paꞌa-nato mala lololek ia sosoa-ndandaan, na, talo bee fo ei bisa paꞌa-nato mala lololek laen sosoa-ndandaan bali? <verse number="14" style="v" />Dadi sosoa-ndandaan talo ia: hatahori mana nggari bini-nggees naa, sama leo hatahori mana tui-bengga Manetualain Dedeꞌa-kokolan. <verse number="15" style="v" />Ma bini-nggees fo mana tuda nai dalak de mbuik kara bido raꞌa heni sara, naa sama leo hatahori mana namanene nala Manetualain Dedeꞌa-kokolan. Tehuu ta dook ka boe ma nitur malanggan mai, de haꞌi neni Dedeꞌa-kokolak naa numa hatahori naa dalen mai. <verse number="16" style="v" />Bini-nggees fo mana tuda ndaa dae batuk naa, sama leo hatahori fo namanene ma simbok nala Manetualain Dedeꞌa-kokolan no nemehokok. <verse number="17" style="v" />Tehuu Dedeꞌa-kokolak naa ta nahuu-naoka. Huu naa de ana ta nakai nala dook ka nai hatahori naa dalen. Neu hatahori laen nakasususak kana nahuu ana simbo Dedeꞌa-kokolak naa, boe ma ana nggari henin tutik kana. <verse number="18" style="v" />Ma bini-nggees fo mana tuda nai dila-nggauk taladan naa, sama leo hatahori fo namanene nala Dedeꞌa-kokolak naa ena. <verse number="19" style="v" />Tehuu ana nasambute nalan seli no ue-osa mata-matak kara fo leo-laꞌo tungga dae-bafok lole-ladan. De basa nesembutek kara raa seti heni Dedeꞌa-kokolak naa numa dalen mai losa ta hambu buna-boak hata esa boe na. <verse number="20" style="v" />Ma bini-nggees fo mana tuda ndaa dae isik, sama leo hatahori fo mana pasa ndiꞌi doon fo ana simbok nala Dedeꞌa-kokolak naa, ma ana tungga Manetualain hihii-nanaun. Basa de ana tao kada hata fo neulauk kara, sama leo bini-nggees mana mabuna-boak naa. Hambu ketuk rabuna-boa lipa laꞌe telu hulu, ketuk lipa laꞌe nee hulu, ma ketuk bali losa lipa laꞌe natun esa.”</para>
+  <para style="s1">Boso tatana lambu tiꞌoek menik lembaneu</para>
+  <para style="r">(Lukas 8:16-18)</para>
+  <para style="p">
+    <verse number="21" style="v" />Yesus kokolak nakandoo numa ofak naa lain mai. Ana fee tamba lololek esa bali nae, “Talo bee! Ei mete mita ena do beik. Hatahori dede lambu tiꞌoek, de ana tatanan nenik lembaneu, do ana natetenden neni mamana susungguk fengga dalen neu. Taa hetu? Mete ma taon talo naa, na, ana ta manggaledo ena. Hatahori muste natetende lambu naa neu mamana demak mita fo hambu manggaledon.<note caller="+" style="x"><char style="xo" closed="false">4:21:</char><char style="xt" closed="false">Mateos 5:15; Lukas 11:33</char></note> <verse number="22" style="v" />De hata fo neni nefunik hatematak ia, neu ko mete-titan. Ma hata fo hatahori ta bubuluk kana hatematak ia, neu ko bubuluk kana.<note caller="+" style="x"><char style="xo" closed="false">4:22:</char><char style="xt" closed="false">Mateos 10:26; Lukas 12:2</char></note> <verse number="23" style="v" />Dadi see ndia kandiꞌi dook, na, nenene matalolole.</para>
+  <para style="p">
+    <verse number="24" style="v" />De, duduꞌa matalolole! Mete ma ei uku-sudi hatahori laen tatao-nonoꞌin, na, hatahori oo uku-sudi ei leo naak boe. Manetualain oo uku-sudi nasafali ei leo naak boe. Tehuu Ndia uku-sudin beran lena bali.<note caller="+" style="x"><char style="xo" closed="false">4:24:</char><char style="xt" closed="false">Mateos 7:2; Lukas 6:38</char></note></para>
+  <para style="p">
+    <verse number="25" style="v" />Dadi mete ma hatahori nau sangga bubuluk tebe-tebe Manetualain hihii-nanaun, na, ana boe nalela. Tehuu mete ma hatahori ta tao matak neu Manetualain hihii-nanaun, na, ana boe namanggoa.”<note caller="+" style="x"><char style="xo" closed="false">4:25:</char><char style="xt" closed="false">Mateos 13:12; 25:29; Lukas 19:26</char></note></para>
+  <para style="s1">Lamatuak Yesus fee lololek bini-nggees mana mori aok</para>
+  <para style="p">
+    <verse number="26" style="v" />Basa boe ma Yesus kokolak tamba nae, “Manetualain mamana parenda-koasan boe namoꞌo, sama leo bini-nggees fo hatahori nggarin nai osin dale. <verse number="27" style="v" />Hatahori naa fali, leo mae ana sunggu do beꞌe, ta nasaneda bini-nggees naa bali, tehuu bini-nggees naa nanumbu ma ana boe namoꞌo nakandoo. <verse number="28" style="v" />Bini-nggees naa mori aon nai dae, boe ma nasarangga kahada, nabuna, naboa, losa naisi. <verse number="29" style="v" />Mete ma hade namatasa ena, na, tenu osik nalela kada neu ketu-koru leo. Manetualain mamana parenda-koasan oo leo naak boe. Basa naar, Manetualain ndia naue-osan.”<note caller="+" style="x"><char style="xo" closed="false">4:29:</char><char style="xt" closed="false">Yoel 3:13</char></note></para>
+  <para style="s1">Lamatuak Yesus fee lololek laꞌe-neu ai deꞌe kadiꞌi anan seli</para>
+  <para style="r">(Mateos 13:31-32, 34; Lukas 13:18-19)</para>
+  <para style="p">
+    <verse number="30" style="v" />Basa naa Yesus tuti kokolan bali nae, “Au fee tamba lololek esa bali, talo ia: ei bisa makasasamak sudik Manetualain hatahorin nara. Mulai makasososan kada hidak ka, tehuu bakadean boe ma ara tamba ramanoꞌu. <verse number="31" style="v" />Naa, nok bali ai deꞌe kadiꞌi anan seli. <verse number="32" style="v" />Tehuu mete ma ita sele-tande tala ai deꞌek naa ena, na, ana mori dadi neu ai huu mana moꞌon lenak. Boe ma mbuik kara mai hae saꞌok ma randunu rai naa.”</para>
+  <para style="p">
+    <verse number="33" style="v" />Yesus nasiꞌe nanori sara tungga sira malelan. <verse number="34" style="v" />Ana nasiꞌe pake lololek, neu nanori hatahorir. Tehuu mete ma no Ndia ana nunin nara, na, Ana nafada lololek naa sosoa-ndandaan lalaꞌen.</para>
+  <para style="s1">Lamatuak Yesus tao nalende ani makarumbuk</para>
+  <para style="r">(Mateos 8:23-27; Lukas 8:22-25)</para>
+  <para style="p">
+    <verse number="35" style="v" />Ledo bobon naa, Yesus bei nai ofak lain. Boe ma Ana nadenu ana nunin nara nae, “Mai ita saꞌe ofak teni serik teu.”</para>
+  <para style="p">
+    <verse number="36" style="v" />Boe ma ara saꞌe ofak sama-sama ro Yesus. De ara laꞌo ela hatahori noꞌuk kara raa ruma naa. Tehuu hambu ketuk saꞌe tungga ofak laen. <verse number="37-38" style="v" />Faik naa Yesus ndae langgan neu kailunu, de Ana sunggu seli numa ofak ikon. Ta dook ka boe ma, ani makarumbuk mai. Rii tufa oe maso neni Yesus asa ofan dale neu, losa sangga sofen. De ana nunin nara ramataꞌu rae mate. Boe ma ara mai fafae Yesus rae, “Papa! Mambadeik dei! Ita sangga tae molo ia ena! Tehuu Papa ta tao matak neu ai!”</para>
+  <para style="p">
+    <verse number="39" style="v" />Yesus namanene nala naa, boe ma nambadeik de Ana kaꞌi anin nae, “Nenee!” Ma Ana parenda neu dano nae, “Lende leo!” No hatematak naa anin hahae ma dano dadi neu lino-lendek leo. <verse number="40" style="v" />Boe ma Yesus nahara berak ana nunin nara nae, “Tao hata de ei basa ngga mamataꞌu talo ia? Ei ta mamahere Au, do?”</para>
+  <para style="p">
+    <verse number="41" style="v" />Basa sara ramataꞌu ma heran, de rakokola aok rae, “Ndia ia see, ee? Losa rii ma anin oo ramanene neun boe, ee!”</para>
+  <chapter number="5" style="c" />
+  <para style="s1">Lamatuak Yesus tao nahai hatahori fo nitu noꞌuk ka saꞌen</para>
+  <para style="r">(Mateos 8:28-34; Lukas 8:26-39)</para>
+  <para style="p">
+    <verse number="1" style="v" />Basa boe ma Yesus no ana nunin nara losa dano Galilea boboan seri numa mamanak esa nade Gerasa. <verse number="2-6" style="v" />Numa mamanak naa, hambu touk esa nitu saꞌen de namulu. Ana leo nai rates sara. Hatu-leledon ana nadaba oek ndule basa mbumbukuk kara marai naa no hola-hola, ma ana kii-bolu nakandoo. Ana tutu nakahina ao-inan pake batu. Barakain sudi selik kana. Ta hambu hatahori esa boe na bisa futu-paꞌan, leo mae pake rante besi boe. Laꞌi-laꞌik ka hatahorir paꞌa lima-ein renik rante besi ena, tehuu ana tao ketu rante besi naa ma tao natepa heni besi numa ein mai. Ndia barakain sudi selik kana, de ta hambu hatahori esa boe na bisa nakatataka nalan.</para>
+  <para style="p">Neu Yesus asa konda numa ofak mai, de heta ein reu mada lai boe ma hatahori kamuluk naa mete-nita sara numa dook ka mai. De ana kalua numa rates ara mai, boe ma nalaik neu sendek luu-langgan neu Yesus matan. <verse number="7-8" style="v" />Yesus mete-nita hatahori naa talo naa, boe ma Ana kokolak nae, “Heeh, nitu! O kalua numa hatahori ia neu leo!”</para>
+  <para style="p">Boe ma hatahori naa kii-bolu nahere nae, “Weeh! O mae tao hata neu au! Au bubuluk O ia, memak Yesus, Manetualain mana koasa mateꞌen Anan. Au hule fo O boso tuni-ndeni au!”</para>
+  <para style="p">
+    <verse number="9" style="v" />Boe ma Yesus natanen nae, “O nadem see?”</para>
+  <para style="p">Hatahori naa naselu nae, “Au nadeng <char style="it">Legion</char>, huu ai noꞌun seli, nok bali soldadur batalion noꞌuk ka.”</para>
+  <para style="p">
+    <verse number="10" style="v" />Basa de nitur pake hatahori naa fo noke Yesus boso nadenu sara kalua numa mamanak naa mai.</para>
+  <para style="p">
+    <verse number="11" style="v" />Hatahorir ranea bafi lalae esa deka-deka no mamanak naa. Bafir raa, basa sara fama te rifun dua. Ara sangga nanaꞌak rai letek tatain. <verse number="12" style="v" />Boe ma nitur raa roke-hule Yesus rae, “Madenu ai maso mini bafir raa miu.”</para>
+  <para style="p">
+    <verse number="13" style="v" />Yesus namanene nala nonoken nara raa, boe ma nakaheik. De nitur raa kalua numa hatahori naa neu, boe ma ara maso reni bafir raa reu. Bafi rifun kaduak kara raa ralaik ralenggu-pikok, boe ma ara tuda tungga mbiak tatain reni dano dale reu, de basa sara mate rasamele reu naa.</para>
+  <para style="p">
+    <verse number="14" style="v" />Hatahori mana manea bafir raa mete-rita mandadik naa, boe ma basa sara ramataꞌu ralan seli. De ara ralaik reu rafada hatahori ndule nggorok kara marai naa. Boe ma hatahori noꞌuk ka kalua mai fo rae mete hata mandadik ena. <verse number="15" style="v" />Ara mai ratonggo ro Yesus, boe ma ara mete-rita hatahori fo nitu saꞌek naa nanggatuuk numa naa. Duduꞌan namaneu ena, de ana pake bua-loꞌa ena. Hatahorir raa mete-rita naa, boe ma ramataꞌu, nahuu ara bubuluk rae, see ndia bisa husi kalua heni nitu noꞌuk kara numa hatahori naa neu, na, ndia memak hatahori ta hohoꞌak tebe-tebe. <verse number="16" style="v" />Boe ma basa sara bengga ndule nggorok rae, sira mete-rita no sira mata deꞌe heli-helin hatahori kamuluk naa hai ena, ma bafir raa fo mate rasamele ena. <verse number="17" style="v" />Boe ma hatahori nggorok marai naa, ara mai roke-hule Yesus fo laꞌo ela sira mamanan.</para>
+  <para style="p">
+    <verse number="18" style="v" />Neu Yesus nae hene ofak dale neu, boe ma hatahori fo bebeik kara nitu saꞌek naa mai noke-hule Yesus fo ndia oo nau tungga boe.</para>
+  <para style="p">
+    <verse number="19" style="v" />Tehuu Yesus ta nau. De nafadan nae, “Malole lenak o fali muu ngga fo mafada o nufanelum lalaꞌen, hata fo Manetualain taon fee o ena. Ma mafada mae, Manetualain sue nalan seli neu o.”</para>
+  <para style="p">
+    <verse number="20" style="v" />Basa boe ma hatahori naa fali neu ngga, de ana laꞌo ndule nusa kota salahunuk fo rasiꞌe roken rae, ‘Dekapolis’. Ana tui hata fo Yesus tao neu ndia ena. Basa hatahori mana ramanene tutuin naa, ara heran ralan seli, de rae, “Memak tetebes!”</para>
+  <para style="s1">Lamatuak Yesus tao nasoda falik Yairus anan numa mamaten mai. Ma ina mana mboꞌa daak fo mana nafaroe Lamatuak Yesus badun</para>
+  <para style="r">(Mateos 9:18-26; Lukas 8:40-56)</para>
+  <para style="p">
+    <verse number="21" style="v" />Basa boe ma Yesus asa saꞌe ofak fali reni dano tatain seri reu. Neu ara konda numa ofak lain mai, te hatahori noꞌun seli mai rakarumbu ralan. <verse number="22" style="v" />Numa naa oo hambu hatahori esa boe nade Yairus. Ndia naa, malanggan uma huhule-haradoik nai kota naa. Neu ana mete-nita Yesus, boe ma ana sendek luu-langgan neu Yesus matan, <verse number="23" style="v" />de ana kokoen nae, “Papa, ee! Au ana feꞌong bei fo teuk salahunu dua, ana namahedi ela kada faa maten. Papa tulun mai fo tao mahain dei.”<note caller="+" style="f"><char style="fr" closed="false">5:23:</char><char style="ft" closed="false">Susura Malalaok dedeꞌa Yunani surak nae, “Papa tulun mai fo ndae limam neun, mita fo ana hai fali, ma nasoda.” Nai naa, “roke ndae limak” sosoa-ndandaan nae, “Tulu-fali tao mahain.” Ana fetok naa teun, dedeꞌa Yunani surak nai lalane ka-42.</char></note></para>
+  <para style="p">
+    <verse number="24" style="v" />Boe ma Yesus tungga Yairus neni uman neu.</para>
+  <para style="p">Neu ara mulai laꞌok, boe ma hatahori noꞌuk ka tunggan de raseseti numa boboa kii-konan mai.</para>
+  <para style="p">
+    <verse number="25" style="v" />Nai hatahori noꞌuk kara raa taladan, hambu inak esa hambu bulak ta tungga doon teuk salahunu dua ena. <verse number="26" style="v" />Ana nabasa tali-doin ma hata-heton nara fo bae neu doter asa. Tehuu ta hambu esa bisa tao nahain boe na. Hedin naa, kada mai-maik nakandoo. <verse number="27-29" style="v" />Inak naa namanene noꞌuk ka laꞌe-neu Yesus ena. De ana naseseti nai hatahori noꞌuk kara raa taladan fo nau deka-deka neu Yesus numa dean mai. Ana duduꞌa nai dalen dale nae, “Sadi au bisa afaroe laꞌe kada Yesus badun, neu ko au hai!”</para>
+  <para style="p">Neu ana nafaroe laꞌe Yesus badun, medak neu te ndia daa mana mboꞌak naa hahae tutik kana. Ana nameda ana hai tebe-tebe ena.</para>
+  <para style="p">
+    <verse number="30" style="v" />Hatematak naa oo Yesus nameda hambu barakaik kalua numa ao-inan mai. Boe ma Ana mbali dea, de mete neu hatahori noꞌuk kara raa. De Ana natane nae, “Ei see ndia nafaroe laꞌe Au badung, ee?”</para>
+  <para style="p">
+    <verse number="31" style="v" />Ana nunin nara raselu rae, “Papa mesa kana mete leo. Hatahori noꞌuk kara iar esa naseseti no esa na. Naa te Papa natane nae, ‘See ndia nafaroe laꞌe Au badung?’ ”</para>
+  <para style="p">
+    <verse number="32" style="v" />Tehuu Yesus leleuk ndule basan, fo sangga bubuluk bebeik kara ia see ndia nafaroe Ndia. <verse number="33" style="v" />Inak naa namanene nala Yesus natane talo naa, boe ma namataꞌu nalan seli. De ana sendek luu-langgan neu Yesus matan fo ana mboꞌa nae, “Papa! Au ndia afaroe laꞌe Papa badun.”</para>
+  <para style="p">
+    <verse number="34" style="v" />Boe ma Yesus naselu neun nae, “Huu mama namahere tebe-tebe neu Au, de mama hai ena. Hatematak ia mama fali uma muu no dale lino-lendek leo, huu mama susa-sonan basan ena.”</para>
+  <para style="p">
+    <verse number="35" style="v" />Yesus bei kola-kola talo naa, boe ma hatahori esa numa Yairus uman mai, de nafada nae, “Kasian ee, ana feꞌok maten ena. Dadi boso makasosotak Papa Meser bali. Ana hae neu bali.”</para>
+  <para style="p">
+    <verse number="36" style="v" />Tehuu Yesus ta tao matak hatahori naa kokolan. De Ana nafada Yairus nae, “O hae mamataꞌu, ee! Mamahere neu kada Manetualain.” <verse number="37" style="v" />Boe ma Yesus laꞌo ela ana nunin laen nara. Tehuu Ana nuni no Petrus, Yakobis ma fadin Yohanis, de ara laꞌo rakandoo. <verse number="38" style="v" />Neu ara losa Yairus uman, ara mete-rita hatahori noꞌuk ka ramue-anggik, ma ramanene ara buꞌi rakarereu. <verse number="39" style="v" />Yesus maso uma dale neu, de natane sara nae, “Tao hata de ei mamue-anggik ma buꞌi makarereu talo ia? Kakanak ia ta mate. Ana kada sunggu a.”</para>
+  <para style="p">
+    <verse number="40" style="v" />Ara ramanene Yesus kokolak talo naa, boe ma basa sara hika rakatitiik kana.</para>
+  <para style="p">Boe ma Ana nadenu basa sara dea reu. Ana noke nala kakanak naa aman no inan ma Ndia ana nunin telu sara, de basa sara maso reni kakanak naa kaman dale reu. <verse number="41" style="v" />Boe ma Yesus toꞌu nala kakanak naa liman, de Ana kokolak neu kakanak naa pake sira dedeꞌa Aram nae, <char style="it">“Talita kum!”</char> (Sosoa-ndandaan nae, “Ana feꞌok! Mambadeik leo!”)</para>
+  <para style="p">
+    <verse number="42-43" style="v" />Medak neu ma, ana fetok naa nambadeik, de ana mulai laꞌok. Boe ma Yesus nadenu inan nae, “Fee kakanak ia naꞌa leo!”</para>
+  <para style="p">Basa hatahorir fo mana mete-rita hata fo mandadik naa, heran bali-bali. Tehuu Yesus kaꞌi nahere sara nae, “Ei boso mafada esa boe na mae, Au asoda falik kana numa mamaten mai ena!”</para>
+  <chapter number="6" style="c" />
+  <para style="s1">Hatahori Nasaret asa timba heni Lamatuak Yesus</para>
+  <para style="r">(Mateos 13:53-58; Lukas 4:16-30)</para>
+  <para style="p">
+    <verse number="1" style="v" />Basa boe ma Yesus no ana nunin nara fali reni Ndia nggoron Nasaret reu. <verse number="2" style="v" />Ndaa no hatahori Yahudi fai huhule-haradoin, Yesus maso neni uma huhule-haradoik dale neu de Ana fee nenorik. Faik naa, hambu hatahori noꞌuk ka reu hule-haradoi. Neu ara ramanene Yesus nenorin, ara heran bali-bali, de rae, “Hatahori ia malelan mata ia, ma! Ana oo naena koasa boe! Talo bee de Ana bisa leo naak? <verse number="3" style="v" />Naa te Ndia kada tukan ai. Ita talela inan, ndia Maria; no fadin nara, sira Yakobis, Yoses, Yudas ma Simon. Ndia oo naena fadi inak hida boe. Ita basa ngga leo nai nggorok esa, ma!” Huu naa de ara mbiri ma rasakele, de ara ta nau ramanene neu sana bali.</para>
+  <para style="p">
+    <verse number="4" style="v" />Boe ma Yesus nafada nae, “Memak tetebes! Hatahori hihiin lenak fee hada-horomatak neu Manetualain mana toꞌu dedeꞌan numa mamanak laen mai. Tehuu nai ndia nggoro-tadun, hatahori ta fee hada-horomatak neun.”<note caller="+" style="x"><char style="xo" closed="false">6:4:</char><char style="xt" closed="false">Yohanis 4:44</char></note></para>
+  <para style="p">
+    <verse number="5-6a" style="v" />Tehuu hatahorir raa dalen nara matea ndoos, de ara ta nau ramahere neu Yesus. Huu naa de Ana heran, de Ana ta nau pake koasan nai naa bali. Ana tao nahai kada hatahori kamahedik esa do dua.</para>
+  <para style="s1">Lamatuak Yesus nadenu Ndia ana nuni kasalahunu duan nara</para>
+  <para style="r">(Mateos 10:5-15; Lukas 9:1-6)</para>
+  <para style="p">
+    <verse number="6b" style="v" />Basa boe ma Yesus laꞌo ndule basa nggoro matia-taik kara, de nanori hatahorir Manetualain hihii-nanaun. <verse number="7" style="v" />Ana noke nala ana nuni kasalahunu duan nara, de Ana nadenu sara laꞌok dua-duak reu tui-bengga Manetualain Hara Lii Malolen. Ana oo fee koasa neu sara boe fo ara bisa husi nitu. <verse number="8-9" style="v" />Ana parenda neu sara nae, “Ei hae meni hata noꞌuk ka nai dalak. Neu ko Manetualain ndia koladun. Hae meni lepa-nggees, tali-doik ma tas. Tehuu meni kada teteꞌe ai, tabu eis ma badu esak ka. <verse number="10" style="v" />Mete ma hambu hatahori simbok ei nai uman nara, na, ei muste leo nai naa losa ei laꞌo seluk bali. <verse number="11" style="v" />Tehuu mete ma losa mamanak esa, ma hatahori marai naa ta nau simbok ma ta nau ramanene neu ei, na, nggani laꞌo ela naa. Ma mafada sara mae, ‘Ei ta nau mamanene, na. De ela numa naa fo ei mesa ngga lemba-masaa neselu-netaam!’ ”<note caller="+" style="f"><char style="fr" closed="false">6:11:</char><char style="ft" closed="false">Nai Susura Malalaok dedeꞌa Yunani surak nae, “ngganggafu heni afu numa sira ein mai”. Lelek naa nai naa hatahori rasiꞌe ngganggafu heni afu numa sira ein mai fo dadi neu tanda nae, hatahori fo ta nau namanene, na, mesa kana lemba-nasaa neselu-netaan. Mete boe nai</char><char style="it">Lukas 10:4-11; Nedenuk kara Tutuin 13:51</char>.</note></para>
+  <para style="p">
+    <verse number="12" style="v" />Basa boe ma ara laꞌo reu tui-bengga Hara Lii Malole naa. Ara rafada basa hatahori fo muste hahae leo numa sira sala-singgon nara mai, de fali fo leo-laꞌo tungga Manetualain hihii-nanaun. <verse number="13" style="v" />Ara oo husi kalua heni nitur boe. Basa naa ara tao mina neu hatahori hedis langgan nara, fo hule-haradoi tao rahai sara. De ara hai tutik kana.<note caller="+" style="x"><char style="xo" closed="false">6:13:</char><char style="xt" closed="false">Yakobis 5:14</char></note></para>
+  <para style="s1">Ara tao risa Yohanis Mana Saranik</para>
+  <para style="r">(Mateos 14:1-12; Lukas 9:7-9)</para>
+  <para style="p">
+    <verse number="14" style="v" />Faik naa, hatahori nai mamanak bee a mesan ralela Yesus ena. Tutuik laꞌe-neu Ndia koasan naa, losa Manek Herodes ndiꞌi doon ena boe. Hambu hatahori rae, “Yohanis Mana Saranik naa nasoda fali nai Yesus aon dale. Huu naa de Ana bisa tao nala tanda heran nara raa lalaꞌen.”</para>
+  <para style="p">
+    <verse number="15" style="v" />Tehuu hambu hatahori laen rae, “Taa! Ia Elia ndia mana nasoda falik nai Ndia aon.” Hambu laen bali rae, “Ndia naa, Manetualain mana toꞌu dedeꞌan laen numa lele uluk mai.”<note caller="+" style="x"><char style="xo" closed="false">6:15:</char><char style="xt" closed="false">Mateos 16:14; Markus 8:28; Lukas 9:19</char></note></para>
+  <para style="p">
+    <verse number="16" style="v" />Neu manek Herodes namanene ara kokolak laꞌe-neu Yesus talo naa, boe ma ana naselu nae, “Ia mete te ndia Yohanis Mana Saranik fo fai maneuk kara au adenu tete rala langgan. Hatematak ia ana nasoda fali numa mamaten mai ena!”</para>
+  <para style="p">
+    <verse number="17-18" style="v" />Manek Herodes nadenu fo tete heni Yohanis Mana Saranik langgan talo naa, nahuu ana naena dedeꞌa moꞌok no Yohanis. Tutuin talo ia: manek Herodes sao nala fadin Felipus saon, nade Herodias. Naa te Felipus no Herodias ta bei raelak. Huu naa de Yohanis kaꞌi-ore laꞌi-laꞌik ka nae, “Papa manek ta bole sao mala papa fadim saon. Naa nalena-langga ita hatahori Yahudir dala-hadan ena!” Leo mae talo naa, tehuu Herodes sao nala inak naa boe. Basa boe ma ana nadenu hatahorir reu humu Yohanis fo mason neni bui dale neu.<note caller="+" style="x"><char style="xo" closed="false">6:17-18:</char><char style="xt" closed="false">Lukas 3:19-20</char></note></para>
+  <para style="p">
+    <verse number="19" style="v" />Huu no Yohanis kaꞌi-ore laꞌi-laꞌik ka ena talo naa, de inak naa nambeda dalek fo nae tao nisan. Tehuu ta bei dadi, te Herodes kena nala Yohanis nai bui dale ena. <verse number="20" style="v" />Boe ma ana nadenu soldadur fo ranea ratalololen.</para>
+  <para style="p">Herodes memak namahia Yohanis. Ana bubuluk nae, Yohanis naa, Manetualain ndia nadenun. Ma Yohanis naa oo hatahori neulauk boe. Herodes memak namahoko namanene Yohanis kokolan. Tehuu laꞌe-laꞌe esa dalen nameda ta neulauk, neu ana namanene Yohanis kokolan boe.</para>
+  <para style="p">
+    <verse number="21" style="v" />Basa boe ma faik esa, Herodias hambu dalak fo bala ndia dalen fo mana nameda hedis. Faik naa, ara tao manek Herodes fai bobonggin. Ara roke hatahori moꞌo-inahuuk kara fo mai raꞌa feta fai bobonggik. Mana maik kara raa, hatahori mana parendar, malangga soldadur ma lasi-lasi hada Galilear. <verse number="22" style="v" />Neu feta bei laꞌok, boe ma Herodias ana feton maso neu lendo. Lelendon lolen seli, de tao namahoko Herodes no fuin nara. Boe ma Herodes noke nalan, de natanen nae, “O mae moke hata numa au mai, na, mafada leo! Neu ko au fee. <verse number="23" style="v" />Leo mae o moke au nusang baꞌe duan oo au fee boe. Au sumba-soo pake Manetualain naden!”</para>
+  <para style="p">
+    <verse number="24" style="v" />Boe ma ana fetok naa neu natane inan nae, “Mama! Tungga mama, na, au oke hata ndia neulaun seli numa papa mai?”</para>
+  <para style="p">Boe ma inan naselu nae, “Naaa! Muu fo moke mala Yohanis naa langgan.”</para>
+  <para style="p">
+    <verse number="25" style="v" />Basa boe ma ana fetok naa lai-laik neni Herodes neu, de nae, “Papa! Au oke fo meni fee au Yohanis langgan, taon neu dulang dale. Hatematak ia leo!”</para>
+  <para style="p">
+    <verse number="26" style="v" />Herodes namanene nala naa, boe ma tendak heni taꞌi dalen tutik kana. Tehuu ana ta bisa leꞌa falik sumba-soon ena, nahuu basa hatahori ramanene ena, na. <verse number="27" style="v" />Basa boe ma ana parenda malangga soldadu esa fo neu tete Yohanis langgan nai bui dale. <verse number="28" style="v" />Boe ma ara tete rala Yohanis langgan, de taon neu dulang dale, fo renin fee ana fetok naa. Ana simbo nala dulang naa, boe ma koꞌo nenin fee inan. <verse number="29" style="v" />Neu Yohanis ana nunin nara ramanene rae, ara haꞌi reni Yohanis langgan ena, boe ma ara mai haꞌi rala Yohanis nenetun, de reu ratoin.</para>
+  <para style="p">Yohanis mamaten tutuin baꞌu kada naa.</para>
+  <para style="s1">Lamatuak Yesus nahao hatahori rifun lima lenak</para>
+  <para style="r">(Mateos 14:13-21; Lukas 9:10-17; Yohanis 6:1-14)</para>
+  <para style="p">
+    <verse number="30" style="v" />Faik esa, Yesus ana nunin nara fo Ana nadenu sara ena reu tui-bengga Manetualain Hara Lii Malolen naa, ara fali de rakabua seluk ro Yesus. Ara rafada basa hata fo ara taok, ma hata fo ranori neu hatahorir ena. <verse number="31" style="v" />Tehuu faik naa, hatahori noꞌuk ka laꞌok reu-mai fo sangga Yesus. Losa-losak ka Ndia no ana nunin nara ta bisa raꞌa-rinu rala ena. Boe ma Yesus nafada ana nunin nara nae, “Mai fo ita teu sangga mamana nees fo ita bisa hahae tala faa dei ma.”</para>
+  <para style="p">
+    <verse number="32" style="v" />De basa sara hene reni ofak dale reu fo reu sangga mamana nees fo dook ka numa nggorok mai.</para>
+  <para style="p">
+    <verse number="33" style="v" />Tehuu hatahori noꞌuk kara raa mete-rita Yesus asa ofan laꞌok loro-loro dano tatain. Boe ma ara kalua numa nggorok reu tungga dala mada laik, de ara losa rakahuluk numa Yesus asa mai. <verse number="34" style="v" />Neu Yesus konda numa ofak lain mai, boe ma Ana mete-nita hatahori noꞌuk ka rahanin ena. Basa boe ma dalen tuda kasian neu sara, nahuu basa sara ta bubuluk nau tao hata, sama leo bibi lombo mana lolo taak. Boe ma Yesus nanori sara Manetualain hihii-nanaun<note caller="+" style="x"><char style="xo" closed="false">6:34:</char><char style="xt" closed="false">Susura Rerekek 27:17; 1 Mane-manek kara 22:17; 2 Israꞌel no Yahuda Tutui Bakahulun 18:16; Yeskiel 34:5; Sakaria 10:2; Mateos 9:36</char></note> <verse number="35-36" style="v" />losa ledo bobok. Boe ma ana nunin nara rafadan rae, “Papa! Malole lenak Papa madenu hatahori iar basa sara reu hasa nanaꞌak nai nggorok matia-taik kara marai iar. Huu ledo bobok ia ena, ma ta hambu nanaꞌak nai ia.”</para>
+  <para style="p">
+    <verse number="37" style="v" />Tehuu Yesus naselu nae, “Bosok! Ei ndia mahao sara leo.”</para>
+  <para style="p">Tehuu ara ratane rasafali rae, “Awii! Mete ma ai mahao hatahori noꞌuk kara iar, na, ai muste kalua doik noꞌun seli. Desi leo tukan esa nggadin teuk esa!<note caller="+" style="f"><char style="fr" closed="false">6:37:</char><char style="ft" closed="false">Susura Malalaok dedeꞌa Yunani huuk nae, “Doi fulak </char><char style="it">denari</char> natun dua.” Lelek naa doi fulak <char style="it">denari</char> esa desi leo tukan esa nggadin faik esa.</note> Ta bisa dadi ai hambu doik desi naa!”</para>
+  <para style="p">
+    <verse number="38" style="v" />Boe ma Yesus naselu nae, “Ei miu matane sudi sara dei, hambu see ndia neni lepa-nggees.”</para>
+  <para style="p">Ara reu ratane basa boe ma ara fali mai, de rafada rae, “Hambu kada roti lima ma iꞌak dua.”</para>
+  <para style="p">
+    <verse number="39" style="v" />Boe ma Yesus nadenu basa hatahori raa fo ranggatuuk rakabubua reu naꞌu lain. <verse number="40" style="v" />De ara reu ranggatuuk rakabubua. Hambu bubuak ruma beke natun esak, ma ruma beke lima huluk.</para>
+  <para style="p">
+    <verse number="41" style="v" />Basa boe ma Yesus haꞌi nala roti kalimak kara ma iꞌa kaduak kara raa. De Ana nasare mbali lalai neu fo noke makasi neu Manetualain. Boe ma Ana fifiꞌi baꞌe roti naa, de Ana loon neu ana nunin nara fo reu babaꞌe fee basa hatahori raa. Ana oo babaꞌe iꞌa kaduak kara raa fee sara boe. <verse number="42" style="v" />Basa sara raꞌa losa rakabete. <verse number="43" style="v" />Ara raꞌa basa boe ma ana nunik kara raa reu raduduru rala nanaꞌa lenan nara, sofe lembaneu salahunu dua.</para>
+  <para style="p">
+    <verse number="44" style="v" />Hatahori mana raꞌak kara raa nai rarain desi rifun lima. Naa bei kada touk kara. Ta bei reke tamba inak kara ma kakanak kara.</para>
+  <para style="s1">Lamatuak Yesus laꞌok nesik oe lain</para>
+  <para style="r">(Mateos 14:22-33; Yohanis 6:16-21)</para>
+  <para style="p">
+    <verse number="45" style="v" />Basa boe ma Yesus nadenu ana nunin nara reu saꞌe ofak fo rakahuluk reni nggoro Betsaida nai dano boboan seri naa reu. Tehuu Ana bei nahani nai naa fo nadenu hatahori noꞌuk kara raa fali reu sara. <verse number="46" style="v" />Neu basa sara fali boe ma Ana hene neni letek esa lain neu fo hule-haradoi.</para>
+  <para style="p">
+    <verse number="47-50" style="v" />Neu fai leꞌodae ena, boe ma Yesus konda fali. Ana mete-nita ana nunin nara ofan ena losa nai dano taladan. Tehuu ara sefe rangginggiok, nahuu ani soru. Neu lole manggaledo, boe ma Yesus neu laꞌo tungga sara. Tehuu Ana laꞌok nesik oe lain. Neu Ana nae laꞌo seli ofak naa ena, boe ma ara mete-ritan. Ara nggengger ralan seli. Boe ma esa natane esa nae, “Weeh! Hata ia? Maro, do hata?”</para>
+  <para style="p">Tehuu Yesus nahara tutik ka nae, “Wei! Ei boso mamataꞌu, ee! Te Au ndia ena.”</para>
+  <para style="p">
+    <verse number="51" style="v" />Neu Yesus hene neni ofak dale neu, boe ma anin lende tutik kana. Ndia ana nunin nara lalaꞌen heran ta basa-basa. <verse number="52" style="v" />Ara bei fo mete-rita Yesus pake koasan fo nahao hatahori rifun lima lenak. Tehuu ara bei ta ralela tebe-tebe Yesus koasan, nahuu sira dalen nara bei matea ndoos.</para>
+  <para style="s1">Hatahori hedis sara marai Ganesaret rame-rame reni Yesus reu</para>
+  <para style="r">(Mateos 14:34-36)</para>
+  <para style="p">
+    <verse number="53" style="v" />Neu ara losa dano tatain seri, boe ma ara see numa kota Genesaret namo seseen. <verse number="54" style="v" />Neu ara konda numa ofak lain mai, hatahori noꞌuk ka mete-rita sara ena. De ara bolu rae, “Wei! Yesus mai ena!” <verse number="55-56" style="v" />Basa sara ralaik reu rafada ndule hatahorir, de ara koꞌo-luꞌa reni hatahori hedis sara mai.</para>
+  <para style="p">Sadi ara ramanene rae, Yesus nai mamanak esa, na, ara rame-rame koꞌo-luꞌa reni hatahori hedis sara fo ralololi sara reu dae moo-loak. Ara duduꞌa rae, “Sadi hatahori hedis sara raa rafaroe laꞌe kada Yesus badun suꞌun oo, ara hai tutik kana boe.” Ara rafaroe laꞌen talo naa, boe ma ara hai tutik kana.</para>
+  <chapter number="7" style="c" />
+  <para style="s1">Hatahori dae-bafok hohoro-lalanen boso nggati heni Manetualain parendan</para>
+  <para style="r">(Mateos 15:1-9)</para>
+  <para style="p">
+    <verse number="1" style="v" />Hambu hatahori Farisi bubuak esa ro meser anggama hida ruma Yerusalem mai fo ratonggo ro Yesus. <verse number="2-5" style="v" />Hatahori Farisir raa toꞌu rahere sira Yahudir dala-hadan. Ndia leo, mete ma hatahori rae raꞌa-rinu, na, muste safe liman tungga sira dala-hadan hihiin. Leo naak oo mete ma fali numa pasar mai boe, ara muste radiu oe dei. Losa-losak sira bua-baꞌun manai dapur, ndia leo urek, pinggak, nggalaas ma cerek, muste safe basa sara tungga sira dala-hadan hihiin, dei fo bole raꞌa-rinu pake sara.</para>
+  <para style="p">Mete ma hambu hatahori Yahudi laen fo ta tao tungga dala-hadak naa, na, hatahori Farisir ramanasa.</para>
+  <para style="p">Neu ara mete-rita Yesus ana nunin nara raꞌa ta safe liman tungga dala-hadak hihiin, de ara ramanasa. Boe ma ara mai fo fee salak neu Yesus rae, “Tao hata de O ana nunim mara raꞌa, tehuu ta safe limak dei? Naa, ara laban ita dala-hadan numa bei-baꞌir mai!”</para>
+  <para style="p">
+    <verse number="6-7" style="v" />Tehuu Yesus naselu nae, “Eir ia, memak hatahori mana kokolak laen, tao laen. Numa lele uluk mai baꞌi Yesaya surak Manetualain hara hehelun ena nae,</para>
+  <para style="q1">‘Hatahorir ia koa-kio Au,</para>
+  <para style="q2">no kada bafan nara, tehuu ta no dalen nara.</para>
+  <para style="q1">Ara tao talo naa oo, naa kada hie-hie a mesan boe.</para>
+  <para style="q2">Ara ta tao matak Au hihii-nanaun,</para>
+  <para style="q3">tehuu ara tungga kada hatahori dae-bafok hihii-nanaun.’<note caller="+" style="x"><char style="xo" closed="false">7:6-7:</char><char style="xt" closed="false">Yesaya 29:13</char></note></para>
+  <para style="p">Ei oo sama leo naak boe. <verse number="8-9" style="v" />Ei laꞌo ela Manetualain hihii-nanaun ena, fo tungga kada hatahori dae-bafok dala-hadan. Memak tungga naa, na, ei malelan seli!</para>
+  <para style="p">
+    <verse number="10" style="v" />Lele uluk baꞌi Musa nafada Manetualain parendan ena nae, ‘Fee hada-horomatak neu ei ina-amam.’ Ma tamba bali nae, ‘Mete ma hatahori esa oꞌole-aꞌali inan do aman, na, muste hukun mates neun.’<note caller="+" style="x"><char style="xo" closed="false">7:10:</char><char style="xt" closed="false">Kalua numa Masir mai 20:12; 21:17; Malangga Anggamar Hohoro-lalanen 20:9; Tui Seluk laꞌe-neu Dala Masodak 5:16</char></note> <verse number="11-12" style="v" />Manetualain fee nenorik talo naa, tehuu ei fee nenorik laen bali. Ei mae, ‘Mete ma hatahori helu-bartaa nae fee ndia bua-baꞌun esa neu Manetualain, na, ta bole pake buas naa fo tulu-fali ina-aman, leo mae ara doidoso ralan seli, huu ana helu-bartaa ena, nae neu ko ana feen neu Manetualain.’ <verse number="13" style="v" />Huu naa de bebeik kara ia Au kokolak ena ae, ei nggari heni Manetualain hihii-nanaun ena, de ei nggatin no hohoro-lalane beuk. Hambu hohoro-lalanek noꞌuk ka, ei nggati sara ena talo naa.”</para>
+  <para style="s1">Dedeꞌa manggarauk fo mana kalua numa hatahori dalen mai</para>
+  <para style="r">(Mateos 15:10-20)</para>
+  <para style="p">
+    <verse number="14" style="v" />Basa boe ma Yesus nanggou nala hatahori laen numa naa, de nae, “Pasa ndiꞌi doom mara dei, fo ei malela. <verse number="15" style="v" />Hata fo maso neni poꞌok dale neu, naa ta tao nanggenggeo hatahori. Tehuu hata fo kalua, naa ndia tao nanggenggeon. <verse number="16" style="v" />[See ndia kandiꞌi dook, na, nenene matalolole, ee!]”<note caller="+" style="f"><char style="fr" closed="false">7:16:</char><char style="ft" closed="false">Susura dedeꞌa Yunani huuk ta surak lalane ka 16 ia.</char></note></para>
+  <para style="p">
+    <verse number="17" style="v" />Basa boe ma Yesus no ana nunin nara laꞌo ela hatahorir raa, de maso reni uma esa dale reu. Boe ma ana nunin nara ratane lololek naa sosoa-ndandaan. <verse number="18-19" style="v" />Yesus naselu nae, “Ei oo ta malela boe, do? Talo ia: hata fo hatahori naꞌan, na, naa malole. Tehuu hata fo ana kalua, naa ndia ta malole. Hata fo ita taꞌan, maso neni poꞌok dale neu, basa naa kalua henin bali. (Lamatuak Yesus lololen naa sosoan nae, hatahori sudi raꞌa hata a mesan, ta kena-kaꞌi.)</para>
+  <para style="p">
+    <verse number="20" style="v" />Tehuu hata fo kalua numa hatahori dalen mai, naa ndia tao nanggenggeon losa Manetualain nunuten, de ta nau nakabua noon. <verse number="21" style="v" />Huu dedeꞌa manggarauk noꞌuk ka kalua numa hatahori dalen mai! Sama leo: duduꞌa manggarauk, laꞌok sala no hatahori fo ta ndia sao toun do ndia sao inan, nemenaꞌo, nekenisa hatahori, <verse number="22" style="v" />bare-naꞌo, hohongge-lelena, tatao manggarauk, pepeko-leleko, tungga kada ao-mbaak hihiin, dale mana mbirik, kokolak tao naboboo hatahori naden, koa ao, ta malela hadak, ma langga batuk.</para>
+  <para style="p">
+    <verse number="23" style="v" />Dadi basa manggarau leo naak kara raa kalua numa hatahori dalen mai. Naa ndia tao nanggenggeon. Losa Manetualain oo nunuten boe.”</para>
+  <para style="s1">Lamatuak Yesus tulu-fali inak esa fo ta hatahori Yahudi</para>
+  <para style="r">(Mateos 15:21-28)</para>
+  <para style="p">
+    <verse number="24" style="v" />Basa boe ma Yesus asa laꞌo ela mamanak naa, de reni kota esa reu nade Tirus. Losa naa boe ma ara maso reni uma esa dale reu, nahuu Yesus ta nau hatahorir bubuluk Ndia nai naa. Tehuu Ana ta bisa nafuni nala aon.</para>
+  <para style="p">
+    <verse number="25-26" style="v" />Numa naa hambu inak esa fo ta hatahori Yahudi. Ndia neni bonggin numa nusa Fenisia nai profensi Siria. Neu ana namanene Yesus mai, de ana neu noke-hule Yesus fo husi heni nitu numa ana feton neu.</para>
+  <para style="p">
+    <verse number="27" style="v" />Tehuu Yesus tee mbolek nae, “Kakanak kara muste raꞌa rakahuluk, dei fo nggari nanaꞌa lenan fee busa.” [Ma sosoan bei nefunik nae, Yesus muste tulu-fali Ndia hatahori Yahudin nakahuluk, dei fo bisa tulu-fali hatahori laen.]</para>
+  <para style="p">
+    <verse number="28" style="v" />Tehuu inak naa naselu nae, “Tebe, Papa! Tehuu busa naa nai mei fengga dalen. Ana oo naꞌa hata fo tuda numa kakanak naa pinggan dale mai boe.” [Ma sosoan nae, kakanak kara raꞌa, na, busa oo hambu naꞌa boe. Leo mae Yesus tulu-fali Ndia hatahorin oo, tehuu Ana muste susuri-memete hatahori laen boe].</para>
+  <para style="p">
+    <verse number="29" style="v" />Yesus namanene nala naa, boe ma nafada nae, “Awii! Mama kokolak ndaa tebe! Dadi mama fali muu ngga leo, te nitu naa kalua numa mama anan mai ena.”</para>
+  <para style="p">
+    <verse number="30" style="v" />Basa boe ma inak naa fali neu ngga. Ana losa uma, te anan mana sunggu selik. Memak nitu naa kalua tebe ena.</para>
+  <para style="s1">Lamatuak Yesus tao nahai hatahori nggoak ma mbakek esa</para>
+  <para style="p">
+    <verse number="31" style="v" />Basa boe ma Yesus asa kalua laꞌo ela kota Tirus, laꞌok tungga tasi tatain resik kota Sidon. Numa naa mai ara laꞌo rakandoo losa dano Galilea. Boe ma ara laꞌo reni nusa kota salahunuk fo rasiꞌe roken rae, ‘Dekapolis’. <verse number="32" style="v" />Nai mamanak naa hambu hatahori esa nggoak ma mbakek. Ndia nonoon nara roon neni Yesus neu. Ara roke-hule Yesus ndae liman neu hatahori naa, fo tao nahain. <verse number="33" style="v" />Boe ma Yesus laꞌo ela hatahori noꞌuk kara raa, de Ana fiti feꞌe no kada hatahori naa. Yesus tao lima kukun neni hatahori naa ndiꞌi doon dua sara dale neu. Basa boe ma Ana tao ambe neu lima kukun de nafaroe hatahori naa maan. <verse number="34" style="v" />Yesus nasare mbali lalai neu, de leꞌa hahaen, boe ma ana parenda pake sira dedeꞌan nae, <char style="it">“Efata!”</char> (Sosoa-ndandaan nae, “Buka leo!”)</para>
+  <para style="p">
+    <verse number="35" style="v" />Ana kokolak talo kada naa, boe ma hatahori naa ndiꞌi doon namanene tutik kana. Hatahori naa maan fo mana barakaik naa, bangganaꞌu tutik ka, de ana mulai kokolak no malole.</para>
+  <para style="p">
+    <verse number="36" style="v" />Basa boe ma dua sara fali reni hatahori noꞌuk kara reu. Yesus ndindia sara nae, “Nenene, ee! Ei boso mafada hatahori mae, Au tao ahai hatahori ia ena.” Leo mae Yesus ndindia nahere sara, tehuu ara tui-bengga sudi nai bee. <verse number="37" style="v" />Hatahori fo mana ramanene tutuik naa, ara heran ralan seli. Ara bese kola rae, “Ta neni babanggak! Hatahori ia tao basan dadi neu malole. Hatahori mbakek bisa namanene. Hatahori nggoak bisa kokolak.”</para>
+  <chapter number="8" style="c" />
+  <para style="s1">Lamatuak Yesus nahao hatahori rifun haa</para>
+  <para style="r">(Mateos 15:32-39)</para>
+  <para style="p">
+    <verse number="1-3" style="v" />Laꞌe esa boe ma hatahori noꞌuk ka mai rakabubua fo ramanene neu Yesus kokolan. Ara tungga Yesus fai telu ena, huu naa de ta ela nanaꞌak ena bali. Boe ma Yesus nanggou nala ana nunin nara, de nae, “Au ameda kasian neu hatahori noꞌuk kara iar. Hambu ketuk numa dae dook mai, ma ara rakabubua faik telu ena, losa ta ela nanaꞌak ena. Malole lenak kara boso fali reu sara ro poꞌo rouk dei. Boso losak, ara ndiꞌa nai dalak.”</para>
+  <para style="p">
+    <verse number="4" style="v" />Yesus ana nunin nara raselu rae, “Papa! Mamanak ia nees, ma dook ka numa nggorok mai. Ta bisa dadi ita tahao hatahori noꞌuk ka talo ia!”</para>
+  <para style="p">
+    <verse number="5" style="v" />Tehuu Yesus natane sara nae, “Ei rotim mara hida de?”</para>
+  <para style="p">Ara raselu rae, “Papa. Ai mambeda kada roti hitu a.”</para>
+  <para style="p">
+    <verse number="6" style="v" />De Yesus nadenu basa hatahori raa fo ranggatuuk reu daer. Boe ma Ana haꞌi nala roti kahituk kara raa, de noke makasi neu Manetulain. Basa boe ma Ana fifiꞌi baꞌe roti naa nenik liman, de fee sara neu ana nunin nara. Boe ma ara reu babaꞌe fee basa hatahorir raa. <verse number="7" style="v" />Ara oo raena iꞌak hida boe. De Yesus noke seluk makasi neu Manetualain soa-neu iꞌak kara raa. Boe ma Ana nadenu ana nunin nara reu babaꞌe fee hatahorir raa bali. <verse number="8-9" style="v" />Basa sara nai rarain hambu hatahori rifun haa. Ara raꞌa losa rakabete. Raꞌa basa boe ma Yesus ana nunin nara reu raduduru nanaꞌa lenan nara, sofe lembaneu hitu. Basa boe ma Yesus nadenu basa sara fali reu sara. <verse number="10" style="v" />Neu ara fali reu sara, boe ma Yesus no ana nunin nara hene reni ofak dale reu, fo reni mamanak esa reu, nade Dalmanuta.</para>
+  <para style="s1">Hatahori Farisi rae tao rakatutudak Lamatuak Yesus</para>
+  <para style="r">(Mateos 16:1-4)</para>
+  <para style="p">
+    <verse number="11" style="v" />Neu Yesus asa losa Dalmanuta, boe ma hambu hatahori hida numa partei anggama Farisi mai ratonggo ro Yesus. Ara rakaseseluk dedeꞌak ro Yesus fo rae ike rakatutudak kana. Ara roke Yesus rae, “Papa! Matudu tanda heran esa fo dadi neu bukti ae, Papa memak hambu koasa numa Manetualain mai.”<note caller="+" style="x"><char style="xo" closed="false">8:11:</char><char style="xt" closed="false">Mateos 12:38; Lukas 11:16</char></note></para>
+  <para style="p">
+    <verse number="12" style="v" />Yesus leꞌa hahaen, de nae, “Mete ma Au amanene ei kokolak talo naa, na, Au fale daleng! Tao hata de ei moke tanda heran? Boso talo naa! Memak hambu tanda heran, tehuu Au ta tao fee ei.”<note caller="+" style="x"><char style="xo" closed="false">8:12:</char><char style="xt" closed="false">Mateos 12:39; Lukas 11:29</char></note></para>
+  <para style="p">
+    <verse number="13" style="v" />Basa boe ma Yesus laꞌo ela sara, de neu fo no ana nunin nara hene fali ofak dale reu. Boe ma ara laꞌo reni dano boboan seri reu.</para>
+  <para style="s1">Lamatuak Yesus fee nenorik nae, besa-besa mia hatahori Farisir leleꞌa-nonoren</para>
+  <para style="r">(Mateos 16:5-12)</para>
+  <para style="p">
+    <verse number="14" style="v" />Neu Yesus asa losa dano taladan, dei de ana nunin nara rasaneda sira lilii reni lepa-nggees. Ara reni kada roti esa. <verse number="15" style="v" />Yesus namanene nala ara kokolak laꞌe-neu roti, boe ma Ana nae, “Ei muste besa-besa! Boso tungga manek Herodes no hatahori Farisir leleꞌa-nonore manggaraun. Sira leleꞌa-nonore manggaraun naa, sama leo laru taꞌik fo hatahori paken tao kaifuu roti dadi namoꞌo.”<note caller="+" style="x"><char style="xo" closed="false">8:15:</char><char style="xt" closed="false">Lukas 12:1</char></note></para>
+  <para style="p">
+    <verse number="16" style="v" />Ana nunin nara ramanene rala Yesus kokolak talo naa, boe ma ara panggananaa. Boe ma ara rakokola aok rae, “Tou lasik kokolak hata naa? Fama te Ana kokolak talo naa, nahuu ita ta teni roti, do?”</para>
+  <para style="p">
+    <verse number="17" style="v" />Tehuu Yesus bubuluk duduꞌan nara. De Ana nafada nae, “Tao hata de ei kokolak laꞌe-neu kada roti! Ei ta malela Au kokolan sosoa-ndandaan, do? Memak ei utem mara ta rakaminak, na! <verse number="18" style="v" />Ei mete-mita no ei mata deꞌe heli-helim mara ena, tehuu ei ta bubuluk sosoa-ndandaan! Nok bali ei pokek kara. Ei mamanene mala no ei ndiꞌi doo heli-helim mara, tehuu ta malela hata esa boe na. Nok bali ei mbakek kara. Ei lilii heni<note caller="+" style="x"><char style="xo" closed="false">8:18:</char><char style="xt" closed="false">Yermia 5:21; Yeskiel 12:2; Markus 4:12</char></note> <verse number="19" style="v" />roti kalimak kara fo Au fifiꞌi baꞌe sara, de ahao hatahori rifun kalimak kara raa ena, do? Faik naa ei maduduru mala roti lenan nara lembaneu hida?”</para>
+  <para style="p">Ara raselu rae, “Lembaneu salahunu dua, Papa.”</para>
+  <para style="p">
+    <verse number="20" style="v" />Yesus natane seluk bali nae, “Ei bei masaneda faik naa, Au fifiꞌi baꞌe roti kahituk fo ahao hatahori rifun kahaak kara raa, do? Ei maduduru mala lenan nara lembaneu hida?”</para>
+  <para style="p">Ara raselu rae, “Hitu, Papa!”</para>
+  <para style="p">
+    <verse number="21" style="v" />Boe ma Yesus nae, “Memak tebe! Ei mete-mita no ei mata ao heli-helim ena, tehuu hata de ei bei ta malela Au koasang numa bee mai?”</para>
+  <para style="s1">Lamatuak Yesus tao nahai hatahori pokek numa Betsaida</para>
+  <para style="p">
+    <verse number="22" style="v" />Basa boe ma Yesus asa laok losa nggorok Betsaida. Numa naa hatahorir ralalaꞌo ro hatahori pokek esa neni Yesus neu. Ara roke-hule neu Yesus fo nafaroe tao nahai hatahori pokek naa. <verse number="23" style="v" />Boe ma Yesus toꞌu nala hatahori naa liman, de noon laꞌo neni nggorok dea neu. De Ana pura ambe neu hatahori naa matan, basa boe ma Ana nafaroe matan. Ana natane nae, “Talo bee? O bisa mete-mita ena, do?”</para>
+  <para style="p">
+    <verse number="24" style="v" />Hatahori naa botik matan fo mete kii-konan, boe ma naselu nae, “Hou! Au mete-ita hatahori laꞌo-laꞌo. Tehuu nok bali au mete-ita ai huuk laꞌo-laꞌo ia!”</para>
+  <para style="p">
+    <verse number="25" style="v" />De Yesus tao seluk liman neu hatahori naa matan bali. Boe ma hatahori naa soba mete seluk, medak neu te matan hai tebe-tebe ena. Hatematak ia ana mete-nita no manggaledok ena. <verse number="26" style="v" />Boe ma Yesus nadenu hatahori naa fali neu ngga, ma Ana fee nesenedak neun nae, “O fali muu ngga leo, tehuu tungga dalak laen. Boso fali muni Betsaida muu bali.”</para>
+  <para style="s1">Petrus nafada nae, Yesus naa, Karistus, ndia Hatahori fo Manetualain henggenee memak kana numa lele uluk mai</para>
+  <para style="r">(Mateos 16:13-20; Lukas 9:18-21)</para>
+  <para style="p">
+    <verse number="27" style="v" />Basa boe ma Yesus no ana nunin nara laꞌok ndule nggorok kara marai Kaisarea Felipi. Yesus natane sara numa dalak nae, “Mete ma tungga hatahori tutuin, na, ara rae, Au ia see?”</para>
+  <para style="p">
+    <verse number="28" style="v" />Ara raselu rae, “Hambu ketuk rae, ‘Yohanis Mana Saranik’. Hambu ketuk bali rae, ‘baꞌi Elia’, fo Manetualain mana toꞌu dedeꞌan lele uluk naa. Laen bali rae, Papa ia, Hatahori esa numa Manetualain mana toꞌu dedeꞌa laen nara numa lele uluk mai.”<note caller="+" style="x"><char style="xo" closed="false">8:28:</char><char style="xt" closed="false">Markus 6:14-15; Lukas 9:7-8</char></note></para>
+  <para style="p">
+    <verse number="29" style="v" />Boe ma Yesus natane bali nae, “Tehuu ei mesa ngga mae, Au ia see?”</para>
+  <para style="p">Petrus naselu nae, “Papa ia, Karistus! Ndia Manetualain henggenee memak kana numa lele uluk mai ena.”<note caller="+" style="x"><char style="xo" closed="false">8:29:</char><char style="xt" closed="false">Yohanis 6:68-69</char></note></para>
+  <para style="p">
+    <verse number="30" style="v" />Tehuu Yesus ndindia sara nae, “Ei boso mafada esa boe na, ee!”</para>
+  <para style="s1">Lamatuak Yesus nafada memak Ndia doidoson ma mamaten</para>
+  <para style="r">(Mateos 16:21-28; Lukas 9:22-27)</para>
+  <para style="p">
+    <verse number="31" style="v" />Basa boe ma Yesus mulai nafada ana nunin nara nae, “Au ia, Hatahori Dae-bafo Isi-isik. Neu ko Au hambu doidosok noꞌuk ka, nahuu lasi-lasi hadak kara, malangga anggama malanggan nara, ma meser anggamar timba heni Au. Neu ko ara tao risa Au, tehuu ndaa no bei-nesan,<note caller="+" style="f"><char style="fr" closed="false">8:31:</char><char style="ft" closed="false">Nai dedeꞌa Yunani, ara mulai reke numa: faik ia (= esa), beꞌe-mai (= dua), bei-nesak (= telu), fai kahaan (= haa). Dadi nai dedeꞌa Yunani, </char><char style="it">μετὰ τρεῖς ἡμέρας (meta treis hēmeras)</char> “nai fai katelun” sosoan nai dedeꞌa Tii, ndia “bei-nesan”. Masaneda, nahuu Lamatuak Yesus maten nai fai limak (reken esa). Beꞌe-mai ndia fai neek (reken dua), Lamatuak Yesus nai rates dale. Bei-nesan, ndia fai menggu (reken telu), Lamatuak Yesus nasoda fali numa mamaten mai. Dadi tungga ita rereke fain, na, Ana mate leꞌodaek dua, boe ma Ana nasoda fali numa mamaten mai.</note> Au asoda fali numa mamates mai.”</para>
+  <para style="p">
+    <verse number="32" style="v" />Yesus nafada no manggaledon talo naa, boe ma Petrus leꞌa nala Yesus neni tataik neu, de ana kaꞌi Yesus nae, “Papa boso kokolak talo naa! Au ta mboꞌi sira liman dai Papa.”</para>
+  <para style="p">
+    <verse number="33" style="v" />Tehuu Petrus kokolak talo naa, ta tungga Manetualain hihii-nanaun. Boe ma Yesus hekor fo mete neni ana nunin laen nara neu. De Ana nahara berak neu Petrus nae, “Hei! Naa, nitur malanggan kokolan naa! Malai heok ia! O duduꞌa tungga kada hatahori dae-bafok hihii-nanaun, te ta tungga Manetualain hihii-nanaun!”</para>
+  <para style="p">
+    <verse number="34" style="v" />Basa boe ma Yesus nanggou nala hatahori laen nara fo mai rakabua ro ana nunin nara. De ana nanori sara nae, “See ndia nau tungga Au, ana muste nakatataka nakandoo tungga-tungga faik. Ana muste lilii heni ndia hihii-nanaun heli-helin fo tungga kada Manetualain hihii-nanaun mesa kana. Leo mae hatahori rae tao risan, ana muste tungga nakandoo a mesan, sama leo hatahori lemba-nasaa ai ngganggen fo neu mate.<note caller="+" style="x"><char style="xo" closed="false">8:34:</char><char style="xt" closed="false">Mateos 10:38; Lukas 9:23; 14:27</char></note> <verse number="35" style="v" />Hatahori mana nau nasoda soa-neu kada ndia ao heli-helin, neu ko masodan naa, sambu do lalo talo kada naa leo! Tehuu hatahori mana sadia mate nahuu ana tungga Au ma tui-bengga Manetualain Hara Lii Malolen, neu ko ana hambu masodak nakandoo no Manetualain.<note caller="+" style="x"><char style="xo" closed="false">8:35:</char><char style="xt" closed="false">Mateos 10:39; Lukas 17:33; Yohanis 12:25</char></note> <verse number="36" style="v" />Nenene ee! Mete ma o hambu basa dae-bafok oe-isin, tehuu Manetualain timba heni o, na, nanalan hata? <verse number="37" style="v" />Leo mae o lemba muni basa dae-bafok oe-isin oo, o ta bisa saiseluk kana neu o samanem boe!</para>
+  <para style="p">
+    <verse number="38" style="v" />Masanenedak, ee! Hatahori manai dae-bafok tanak ia tatao-nonoꞌi manggaraun nara mata-matak kara. Ara ta tao matak neu Manetualain. De see ndia mae tungga Au, do mae toꞌu Au nenoring, neu ko Au oo mae manakun nai Manetualain matan boe. Au, Hatahori Dae-bafo Isi-isik ia, neu ko Au fali mai numa nusa tetuk do inggu temak mai. Ma Manetualain atan nara ruma nusa tetuk do inggu temak mai oo, konda sama-sama ro Au boe. Ai konda numa nusa tetuk do inggu temak mai no Amak koasan ta neni babanggak, dei fo hatahori bubuluk Au ia see.</para>
+  <chapter number="9" style="c" />
+  <para style="p">
+    <verse number="1" style="v" />Ei boso lilii-ndondou Au kokolan ia. Hambu ketuk numa ei marai iar, bei ta mate, losa neu ko mete-rita Manetualain toꞌu parenda no koasa ina-huuk.”</para>
+  <para style="s1">Lamatuak Yesus mata-aon nasafali ma bualoꞌa-papaken nanggahadok numa letek lain</para>
+  <para style="r">(Mateos 17:1-13; Lukas 9:28-36)</para>
+  <para style="p">
+    <verse number="2" style="v" />Seli faik nee numa Yesus nafada laꞌe-neu mamaten ma nesoda falin numa mamates mai, boe ma Yesus noke no Petrus, Yakobis ma Yohanis, fo ara sama-sama reu hene lete demak esa fo ta hambu hatahori nai naa. Neu ara losa lain, de ara mete-rita Yesus mata-aon nasafali. <verse number="3" style="v" />Ma Ndia bualoꞌa-papaken dadi neu muti manggahadok. Nai dae-bafok ia, ta hambu hata esa muti manggahadon lena heni Yesus bualoꞌa-papaken naa. <verse number="4" style="v" />Medak neu ma, ara mete-rita Yesus kola-kola no baꞌi Elia ma baꞌi Musa.</para>
+  <para style="p">
+    <verse number="5-6" style="v" />Petrus asa ramataꞌu ralan seli. Boe ma Petrus pangganaa, losa ana kokolak sadi ndaa. De ana nafada Yesus nae, “Papa! Ai mameda malole nai ia! Dadi malole lenak ai mambaririik laak telu. Esa soa-neu Papa, esa soa-neu baꞌi Musa, ma esa bali soa-neu baꞌi Elia.”</para>
+  <para style="p">
+    <verse number="7" style="v" />Basa boe ma sosoꞌak konda mai de tatana nala sara. Boe ma ara ramanene harak esa numa sosoꞌak naa mai nae, “Nenene, ee! Yesus ia, Au Ana susueng. Ei nenene matalolole neun leo!”<note caller="+" style="x"><char style="xo" closed="false">9:7:</char><char style="xt" closed="false">2 Petrus 1:17-18; Mateos 3:17; Markus 1:11; Lukas 3:22</char></note></para>
+  <para style="p">
+    <verse number="8" style="v" />Neu Petrus asa ramanene rala harak naa, boe ma ara leleuk ndule basan, tehuu medak neu ma ara ta mete-rita hatahori laen bali. Kada Yesus mesa kana.</para>
+  <para style="p">
+    <verse number="9" style="v" />Basa boe ma Yesus no ana nunin nara konda numa letek naa mai. Yesus helu sara nae, “Hata fo ei mete-mitan bebeik kara ia, ei boso mafadan neu hatahori esa boe na. Au ia, Hatahori Dae-bafo Isi-isik. Au muste mate dei. Neu ko mete ma Au asoda fali numa mamates mai ena, na, dei fo ei bole mafada hatahori.”</para>
+  <para style="p">
+    <verse number="10" style="v" />Ara toꞌu ratalolole Yesus hara hehelun naa, de ara ta rafada hatahori esa boe na. Tehuu telu sara mulai ratatane aok rae, “Ana kokolak nae, ‘Ana nasoda fali numa mamaten mai’, sosoan hata, ee? Talo bee, ee?”</para>
+  <para style="p">
+    <verse number="11" style="v" />Boe ma ara ratane Yesus rae, “Meser anggamar raa rae, ‘Baꞌi Elia muste mai nakahuluk, dei fo Karistus mai.’ Tehuu tungga Papa, na, talo bee?”<note caller="+" style="x"><char style="xo" closed="false">9:11:</char><char style="xt" closed="false">Maleaki 4:5; Mateos 11:14</char></note></para>
+  <para style="p">
+    <verse number="12" style="v" />Yesus naselu nae, “Memak tebe! Baꞌi Elia muste mai nakahuluk, fo nasosoi dalak soa-neu Karistus, Hatahori naa ndia Manetualain henggenee memak kana numa lele uluk mai ena. De talo bee? Ei bei ta malela hata fo ara surak kana ena nai Manetualain Susura Malalaon soa-neu Hatahori Dae-bafo Isi-isik naa, do? Ara surak memak kana ena rae, neu ko mete ma Ana mai ena, na, hatahori rakasususak kana, losa ara nau tao risan. <verse number="13" style="v" />De ei muste pasa ei ndiꞌi doom mara matalolole, ee! Baꞌi Elia naa memak mai ena. Tehuu hatahori rakasususak kana tungga sira hihiin. Naa oo, ndaa no hata fo baꞌir surak memak kana numa lele uluk mai ena boe.”</para>
+  <para style="s1">Lamatuak Yesus tao nahai kakana nitu saꞌek</para>
+  <para style="r">(Mateos 17:14-21; Lukas 9:37-43)</para>
+  <para style="p">
+    <verse number="14" style="v" />Neu Yesus no ana nunin kateluk kara raa ratonggo fali ro ana nunin laen, ara mete-rita hatahori noꞌuk ka rakabua. Hatahori noꞌuk kara raa mai, de ara mete-rita Yesus ana nunin laen rareresi ro meser anggamar. <verse number="15" style="v" />Neu hatahori noꞌuk kara raa mete-rita Yesus, ara nggengger nahuu ara duꞌa rae, Ana bei nai letek lain. Boe ma ara ralaik reu ratonggo ro Yesus.</para>
+  <para style="p">
+    <verse number="16" style="v" />Boe ma Yesus natane sara nae, “Ei mareresi hata nai ia?”</para>
+  <para style="p">
+    <verse number="17" style="v" />Hambu hatahori esa mai, de nae, “Papa, nenene dei! Au uni au ana toung mai, fo Papa tao mahain dei. Nggoak, ta bisa kokolak nala, huu nitu saꞌen. <verse number="18" style="v" />Mete ma nitu naa masok ena, na, ana fae nggari kakana ia ao-inan neu daer. Boe ma bafan lua fufudek kara, ma ana henggu nisin. Ao-inan barakai ndoos leo ai tuuk ia. Au oke Papa ana nunin nara fo ara husi heni nitu naa. Tehuu ara ta bisa tao hata esa boe na.”</para>
+  <para style="p">
+    <verse number="19" style="v" />Yesus namanene nala naa, boe ma Ana mboka sara nae, “Weeh! Eir ia, sudi selik kana ena! Au anori ei laꞌi-laꞌik ka ena, tehuu ei ta malela Au nenoring no malole. Ma ei ta mamahere tebe-tebe neu Au! Au ahani ua ei losa faik hida bali? Mai fo mia kakanak naa ia mai!” <verse number="20" style="v" />Boe ma ara koꞌo roo kakanak naa neni Yesus neu. Tehuu neu nitu mete-nita Yesus, boe ma ana fae nggari kakanak naa losa tuda loli-loli neu daer, ma bafan lua fufudek kara.</para>
+  <para style="p">
+    <verse number="21" style="v" />Basa boe ma Yesus natane kakanak naa aman nae, “O anan dadi talo ia, ndia bee ena?”</para>
+  <para style="p">Kakanak aman naselu nae, “Numa kadiꞌi anan mai. <verse number="22" style="v" />Nitu naa nau tao nisa kakanak ia dook ka ena. Ana tumbu piru au anang laꞌi-laꞌik ka neni aꞌi dale neu, ma ana nggarin neni oe dale neu losa nasamele. Dadi Papa tulun dei! Mete ma bisa, na, Papa kasian neu ai fo tao mahai kakanak ia dei.”</para>
+  <para style="p">
+    <verse number="23" style="v" />Yesus naselu nae, “Tao hata de o mae, ‘mete ma bisa’? Memak Au bisa tao hata a mesan, sadi hatahori ramahere dei!”</para>
+  <para style="p">
+    <verse number="24" style="v" />Basa boe ma tou lasik naselu leo bali nae buꞌi ia, ma nae, “Papa! Memak au amahere ena. Tehuu tulun fo au nemehehereng boe natea bali!”</para>
+  <para style="p">
+    <verse number="25" style="v" />Faik naa, Yesus mete-nita hatahori noꞌuk ka mulai rakarumbu mai ruma naa. De Ana parenda nitu naa nae, “Weeh, nitu! O kalua numa kakanak ia mai leo, fo ana bisa namanene ma kokolak nala. O boso maso fali muni ndia neu bali!”</para>
+  <para style="p">
+    <verse number="26" style="v" />Nitu namanene Yesus kokolak talo naa, boe ma ana kii-bolu nahere. Ana fae nggari kakanak naa neu daer, de leꞌa kede-kede, basa dei de ana kalua laꞌo elan. Boe ma kakanak naa ndiꞌa nok bali sangga mate ia ena. De hatahorir marai naa rae, “Naa! Maten ena!”</para>
+  <para style="p">
+    <verse number="27" style="v" />Tehuu Yesus toꞌu nala kakanak naa liman de nambadedeik kana. Boe ma ana nambadeik tutik kana.</para>
+  <para style="p">
+    <verse number="28" style="v" />Basa boe ma Yesus no ana nunin nara laꞌo ela mamanak naa, fo ara maso reni uma esa dale reu. Numa naa, ana nunin nara ratane Yesus rae, “Papa! Tao hata de bebeik kara ia, ai ta bisa husi nitu naa?”</para>
+  <para style="p">
+    <verse number="29" style="v" />Boe ma Yesus nafada nae, “Nenene matalolole! Nitur memak manggarauk. Dadi mete ma ei ta hule-haradoi moke tutulu-fafalik numa Manetualain mai, na, ei ta bisa mabeꞌi husi nitur matak leo naak.”</para>
+  <para style="s1">Lamatuak Yesus nafada seluk bali Ndia mamaten</para>
+  <para style="r">(Mateos 17:22-23; Lukas 9:43-45)</para>
+  <para style="p">
+    <verse number="30" style="v" />Basa boe ma Yesus no ana nunin nara laꞌo ela mamanak naa, fo ara maso reni nusa Galilea reu. Faik naa, Yesus ta nau hatahorir bubuluk Ndia nai naa, <verse number="31" style="v" />huu Ana nau nanori kada Ndia ana nunin nara. Ana nafada sara nae, “Ta dook ka te ara rae seꞌo heni Au uni hatahori laen nara uu. Boe ma ara tao risa Au, Hatahori Dae-bafo Isi-isik ia. Memak Au mate, tehuu neu ko bei-nesan, Au asoda fali numa mamates mai.”<note caller="+" style="f"><char style="fr" closed="false">9:31:</char><char style="ft" closed="false">Nai dedeꞌa Yunani, ara mulai reke numa: faik ia (= esa), beꞌe-mai (= dua), bei-nesak (= telu), fai kahaan (= haa). Dadi nai dedeꞌa Yunani, μετὰ τρεῖς ἡμέρας (meta treis hēmeras) ‘nai fai katelun’ sosoan nai dedeꞌa Tii, ndia ‘bei-nesan’. Masaneda, nahuu Lamatuak Yesus maten nai fai limak (reken esa). Beꞌe-mai ndia fai neek (reken dua), Lamatuak Yesus nai rates dale. Bei-nesan, ndia fai menggu (reken telu), Lamatuak Yesus nasoda fali numa mamaten mai. Dadi tungga ita rereke fain, na, Ana mate leꞌodaek dua, boe ma Ana nasoda fali numa mamaten mai.</char></note></para>
+  <para style="p">
+    <verse number="32" style="v" />Yesus nafada talo naa, tehuu ana nunin nara panggananaa. Te ara ta rambarani ratane seluk Yesus kokolan naa sosoa-ndandaan hata.</para>
+  <para style="s1">Lamatuak Yesus ana nunin nara rareresi rae, see ndia moꞌon lenak</para>
+  <para style="r">(Mateos 18:1-5; Lukas 9:46-48)</para>
+  <para style="p">
+    <verse number="33" style="v" />Basa boe ma Yesus asa laꞌok losa Kapernaum. Neu ara maso reni uma dale reu, boe ma Yesus natane ana nunin nara nae, “Bebeik kara ia ei mareresi hata numa dalak naa?”</para>
+  <para style="p">
+    <verse number="34" style="v" />Tehuu ta hambu esa nambarani naselu, nahuu neu ara bei laꞌok numa dalak, ara rareresi rae, see ndia moꞌon lenak numa sira basa sara mai.<note caller="+" style="x"><char style="xo" closed="false">9:34:</char><char style="xt" closed="false">Lukas 22:24</char></note></para>
+  <para style="p">
+    <verse number="35" style="v" />Boe ma Yesus nanggatuuk fo nanori sara nae, “See ndia nau dadi hatahori moꞌo-inahuuk, na, leleo-lalaꞌon muste dadi tebe-tebe sama leo hatahori kadiꞌik fo naono-lalau basa hatahorir.”<note caller="+" style="x"><char style="xo" closed="false">9:35:</char><char style="xt" closed="false">Mateos 20:26-27; 23:11; Markus 10:43-44; Lukas 22:26</char></note></para>
+  <para style="p">
+    <verse number="36" style="v" />Boe ma Yesus koꞌo nala kakana ana esa numa naa, de ana fali neni ana nunin nara taladan neu. De Ana kokolak nae, <verse number="37" style="v" />“See nau tungga Au fo ana naono-lalau hatahori kadiꞌik sama leo kakanak ia, na, sosoa-ndandaan nae, hatahori naa naono-lalau Au boe. Ma ana oo naono-lalau Au Amang fo mana madenu Au uni dae-bafok ia mai.”<note caller="+" style="x"><char style="xo" closed="false">9:37:</char><char style="xt" closed="false">Mateos 10:40; Lukas 10:16; Yohanis 13:20</char></note></para>
+  <para style="s1">See ndia dadi neu ita hatahorin?</para>
+  <para style="r">(Lukas 9:49-50)</para>
+  <para style="p">
+    <verse number="38" style="v" />Basa boe ma Yesus ana nunin Yohanis kalaak nae, “Papa! Laꞌe esa ai mete-mita hatahori esa pake Papa naden fo ana husi nitu. De ai kaꞌin, nahuu ndia naa, ta ita hatahorin.”</para>
+  <para style="p">
+    <verse number="39" style="v" />Tehuu Yesus naselu nae, “Weeh! Ei boso kaꞌin. Huu see ndia pake Au nadeng fo tao tanda heran, na, ana ta kokolak tao naboboo Au nadeng. <verse number="40" style="v" />Mete ma ana ta lena-laba ita, sosoa-ndandaan nae, ndia naa oo ita hatahorin boe.<note caller="+" style="x"><char style="xo" closed="false">9:40:</char><char style="xt" closed="false">Mateos 12:30; Lukas 11:23</char></note> <verse number="41" style="v" />Masaneda matalolole! Mete ma hambu hatahori bubuluk nae, ei tungga Karistus, boe ma ana tulu-fali ei, na, neu ko Manetualain ta lilii heni hatahori naa sosota-mamanggun. Leo mae ana fee ei minu kada oe hiek nggalaas esa oo, Manetualain ta lilii hatahori naa boe.”<note caller="+" style="x"><char style="xo" closed="false">9:41:</char><char style="xt" closed="false">Mateos 10:42</char></note></para>
+  <para style="s1">Boso makamiminak mia kilu-salak</para>
+  <para style="r">(Mateos 18:6-9; Lukas 17:1-2)</para>
+  <para style="p">
+    <verse number="42" style="v" />Basa boe ma Yesus nafada sara bali nae, “Mete ma hambu hatahori tao kakana ana esa leo-laꞌo tao salak, losa kakanak naa ta namehere neu Au bali, na, besa-besa, ee! Malole lenak haꞌi batu moꞌok esa,<note caller="+" style="f"><char style="fr" closed="false">9:42:</char><char style="ft" closed="false">Susura Malalaok dedeꞌa Yunani surak nae, ‘batu lelenduk’ fo pake mol hade-nggandum.</char></note> fuli neu hatahori naa boliin, fo feen tena neni tasi demak dale neu.</para>
+  <para style="p">
+    <verse number="43" style="v" />Mete ma o tao salak munik o limam, na, tete henin leo! Malole lenak o maso nusa tetuk do inggu temak muu, muni kada lima seserik lena heni ara nggari o muni aꞌi mbila ta kala matek muu, muni o limam dua sara.<note caller="+" style="x"><char style="xo" closed="false">9:43:</char><char style="xt" closed="false">Mateos 5:30</char></note> <verse number="44" style="v" />[Aꞌi mbila ta kala matek naa, memak mamana doidosok. Ulek kara marai naa ta hahae tao kaboo mburuk.]<note caller="+" style="f"><char style="fr" closed="false">9:44:</char><char style="ft" closed="false">Susura dedeꞌa Yunani huuk ma lasin lenak ta surak lalanek ka-44 ia.</char></note> <verse number="45" style="v" />Mete ma o tao salak munik o eim, na, tete henin leo! Malole lenak o maso nusa tetuk do inggu temak muu, muni kada ei seserik lena heni ara nggari o muni aꞌi mbila ta kala matek muu, muni o eim dua sara. <verse number="46" style="v" />[Aꞌi mbila ta kala matek naa, memak mamana doidosok. Ulek kara marai naa ta hahae tao kaboo mburuk.]<note caller="+" style="f"><char style="fr" closed="false">9:46:</char><char style="ft" closed="false">Susura dedeꞌa Yunani huuk ma lasin lenak ta surak lalane ka-46 ia.</char></note> <verse number="47" style="v" />Mete ma o tao salak munik o matam, na, edo henin leo! Malole lenak o maso nusa tetuk do inggu temak muu, muni kada mata seserik lena heni ara nggari o muni aꞌi mbila ta kala matek muu, muni o matam dua sara.<note caller="+" style="x"><char style="xo" closed="false">9:47:</char><char style="xt" closed="false">Mateos 5:29</char></note></para>
+  <para style="q1">
+    <verse number="48" style="v" />‘Aꞌi mbila ta kala matek naa,</para>
+  <para style="q2">memak mamana doidosok.</para>
+  <para style="q2">Ulek kara marai naa ta hahae tao kaboo mburuk.’<note caller="+" style="x"><char style="xo" closed="false">9:48:</char><char style="xt" closed="false">Yesaya 66:24</char></note></para>
+  <para style="p">
+    <verse number="49" style="v" />Au nenoring ia, memak berak ka. De see ndia nau tungga Au, na, ana muste nakatataka tungga nakandoo, sama leo mbaa fo hatahori mamasin, ma ara seꞌin neu aꞌi, mita fo mbaa naa nakai nala dook ka.</para>
+  <para style="p">
+    <verse number="50" style="v" />Masik naa, malole. Ita paken fo tao nalada nanaꞌak kara. Tehuu mete ma masik naa mami ena, na, nenenin hata bali? Ita nggari henin leo. Ei oo muste dadi sama leo masik boe, fo leo-laꞌo no masue-laik mia basa hatahori lalaꞌen.<note caller="+" style="x"><char style="xo" closed="false">9:50:</char><char style="xt" closed="false">Mateos 5:13; Lukas 14:34-35</char></note></para>
+  <para style="p">De ei hahae mareresi bali mae, see ndia hatahori moꞌo-inahuuk, do see ndia kadiꞌik!”</para>
+  <chapter number="10" style="c" />
+  <para style="s1">Hatahori Farisi sangga dalak fo ike Lamatuak Yesus laꞌe-neu sasaok-nemeketuk</para>
+  <para style="r">(Mateos 19:1-12; Lukas 16:18)</para>
+  <para style="p">
+    <verse number="1" style="v" />Basa boe ma Yesus asa reni profensi Yudea reu, ma mamanak laen manai lee Yarden boboan dulu. Yesus nai mamanak bee a mesan, hatahori noꞌuk kara mai rakarumbu ralan. De Yesus nanori sara sama leo nasiꞌen.</para>
+  <para style="p">
+    <verse number="2" style="v" />Hambu hatahori Farisi hida mai fo rae tao rakatudak kana. Ara ratanen rae, “Tungga ita anggaman hohoro-lalanen, mete ma touk esa sao ena, na, ana bole namaketu no saon, do taa?”</para>
+  <para style="p">
+    <verse number="3" style="v" />Yesus naselu nae, “Masaneda dei! Hohoro-lalanek laꞌe-neu sao holu-ndaek fo baꞌi Musa tao elan fee ita nae leo bee?”</para>
+  <para style="p">
+    <verse number="4" style="v" />Ara raselu rae, “Baꞌi Musa hohoro-lalanen nae, hatahorir bole ramaketu, sadi fee susura nemeketuk neu sao inan dei.”<note caller="+" style="x"><char style="xo" closed="false">10:4:</char><char style="xt" closed="false">Tui Seluk laꞌe-neu Dala Masodak 24:1-4; Mateos 5:31</char></note></para>
+  <para style="p">
+    <verse number="5" style="v" />Yesus bala nae, “Weeh! Nenene, ee! Huu ei langga batum mara dei, de baꞌi Musa surak talo naa! <verse number="6" style="v" />Boso lilii-ndondou tutui makasososak, neu lelek Manetulain adu lalai no dae-inak! Neni surak nae,</para>
+  <para style="q1">‘Manetualain adu hatahori dae-bafok, touk no inak.<note caller="+" style="x"><char style="xo" closed="false">10:6:</char><char style="xt" closed="false">Tutui Makasososak 1:27; 5:2</char></note></para>
+  <para style="q2">
+    <verse number="7" style="v" />Huu naa de touk muste laꞌo ela ndia inan ma aman,</para>
+  <para style="q3">fo neu leo-laꞌo dalek esa no saon</para>
+  <para style="q3">
+    <verse number="8" style="v" />huu dua sara dadi reu esa ena.’<note caller="+" style="x"><char style="xo" closed="false">10:8:</char><char style="xt" closed="false">Tutui Makasososak 2:24</char></note></para>
+  <para style="p">
+    <verse number="9" style="v" />Mete ma Manetualain mesa kana ndia adu nala dua sara dadi reu esa ena, na, hatahori dae-bafok boso mabingga-baꞌe sara bali!”</para>
+  <para style="p">
+    <verse number="10" style="v" />Basa boe ma Yesus no kada ana nunin nara maso reni uma esa dale reu. Numa naa, ara ratane Yesus nenorin bebeik kara ia.</para>
+  <para style="p">
+    <verse number="11" style="v" />Yesus naselu nae, “See ndia namaketu no sao inan, de ana sao seluk, na, ana hohongge-lelena naa ena! <verse number="12" style="v" />Sao inak oo leo naak boe! Mete ma ana namaketu no saon, de ana sao seluk, na, ana oo hohongge-lelena naa boe!”<note caller="+" style="x"><char style="xo" closed="false">10:12:</char><char style="xt" closed="false">Mateos 5:32; 1 Korentus 7:10-11</char></note></para>
+  <para style="s1">Lamatuak Yesus kokolak fee babaꞌe-babatik neu kakana anar</para>
+  <para style="r">(Mateos 19:13-15; Lukas 18:15-17)</para>
+  <para style="p">
+    <verse number="13" style="v" />Faik esa, hambu hatahorir roo sira anan nara reni Yesus reu, fo roke-hule Ana ndae liman ma kokolak fee babaꞌe-babatik neu sara. Tehuu Yesus ana nunin nara rahara berak reu hatahorir raa.</para>
+  <para style="p">
+    <verse number="14" style="v" />Yesus mete-nita talo naa, boe ma Ana namanasa ana nunin nara nae, “Ela kakana anar raa reni Au mai! Boso mamanggengge sara! Huu hatahori mana sama leo kakana anar iar, ndia Manetualain hatahorin. <verse number="15" style="v" />Ei masaneda matalolole! See ndia nau mai nasare Manetualain, na, muste dalen hii nalan seli neun, sama leo kakana anar dalen nara hii ralan seli neu sira inan ma aman. Mete ma ta leo naak, na, ara ta randaa dadi reu Manetualain hatahorin.”<note caller="+" style="x"><char style="xo" closed="false">10:15:</char><char style="xt" closed="false">Mateos 18:3</char></note> <verse number="16" style="v" />Basa boe ma Yesus holu nala kakana anar raa, ma Ana ndae liman neu esa-esak langgan, de Ana fee babaꞌe-babatik neu sara.</para>
+  <para style="s1">Hatahori kamasuꞌik sangga dalak fo nasoda nakandoo no Manetualain</para>
+  <para style="r">(Mateos 19:16-30; Lukas 18:18-30)</para>
+  <para style="p">
+    <verse number="17" style="v" />Neu Yesus asa sangga laꞌo, boe ma hatahori kamasuꞌik esa nalaik mai fo nae natonggo no Yesus. Ana sendek luu-langgan nai Yesus matan, de natane nae, “Papa Meser mana hambu hada-horomatak. Au ae atane baꞌu anak. Talo ia Papa. Au muste tao talo bee fo au bubuluk no tetuk ae, au bisa maso nusa tetuk do inggu temak fo au asoda akandoo ua Manetualain?”</para>
+  <para style="p">
+    <verse number="18" style="v" />Yesus naselu nae, “Tao hata de o moke Au mae ‘mana hambu hada-horomatak’? Ta hambu hatahori esa boe na mana hambu hada-horomatak, kada Manetualain mesa kana. <verse number="19" style="v" />O bubuluk Manetualain parendan numa lele uluk mai ena nae,</para>
+  <para style="q2">‘Boso makanisa hatahori;</para>
+  <para style="q2">Boso hohongge-lelena;</para>
+  <para style="q2">Boso mamanaꞌo;</para>
+  <para style="q2">Boso dadi sakasii pepeko-lelekok;</para>
+  <para style="q2">Boso pakanaꞌe mala hatahori hatan;</para>
+  <para style="q2">Ma fee hada-horomatak neu o inam ma o amam.’ ”<note caller="+" style="x"><char style="xo" closed="false">10:19:</char><char style="xt" closed="false">Kalua numa Masir mai 20:12-16; Tui Seluk laꞌe-neu Dala Masodak 5:16-20</char></note></para>
+  <para style="p">
+    <verse number="20" style="v" />Hatahori naa naselu nae, “Tebe, Papa Meser! Mulai numa muri-sorung mai, au tungga basa parenda raa ena.”</para>
+  <para style="p">
+    <verse number="21" style="v" />Yesus dalen kasian neu hatahori naa. Boe ma Ana nae, “Tebe! Tehuu bei ela matak esa bali. Hatematak ia o fali muu ngga leo fo seꞌo heni basa o hata-hetom lalaꞌen. Doin nara, o muu babaꞌe fee neu hatahori mana susak kara. Basa naa, o fali mai fo tungga Au leo. Dei fo Manetualain bala fee o hata-heto manahetak nai nusa tetuk do inggu temak.”</para>
+  <para style="p">
+    <verse number="22" style="v" />Hatahori naa namanene nala Yesus kokolan talo naa, boe ma dalen nakalulutu. De ana fali neu ngga no dalen susa nalan seli, nahuu suꞌin noꞌun seli.</para>
+  <para style="p">
+    <verse number="23" style="v" />Boe ma Yesus mete neu-mai, de kokolak neu ana nunin nara nae, “Nenene, ee! Hatahori kamasuꞌik memak susa laꞌe esak kana maso nusa tetuk do inggu temak!”</para>
+  <para style="p">
+    <verse number="24" style="v" />Ana nunin nara ramanene rala Yesus kokolak talo naa, boe ma ara panggananaa. Boe ma Yesus kokolak seluk bali nae, “Nenene matalolole! Memak manggataꞌan seli, mete ma nau dadi neu Manetualain hatahorin. Boso duduꞌa mae, muda hiek. <verse number="25" style="v" />Hatahori kamasuꞌik maso nusa tetuk do inggu temak fo dadi neu Manetualain hatahorin, naa manggataꞌan sama leo banda onta moꞌok esa maso neni lalaen neu nesik ndandauk bolon.”</para>
+  <para style="p">
+    <verse number="26" style="v" />Yesus kokolan naa, tao nala basa sara boe panggananaa. Boe ma ara ratatane aok rae, “Mete ma tebe leo naak, na, see ndia bisa hambu nala masoi-masodak, ee?”</para>
+  <para style="p">
+    <verse number="27" style="v" />Yesus mete sara esa-esak, boe ma Ana nae, “Soa-neu hatahori dae-bafok memak ta bisa dadi. Tehuu boso lilii-ndondou: soa-neu Manetualain basan bisa dadi!”</para>
+  <para style="p">
+    <verse number="28" style="v" />Basa boe ma Petrus soꞌuk kokolak nae, “Papa. Ai laꞌo ela basa ai hata-heton lalaꞌen, fo tungga Papa. Tehuu ai hambu hata?”</para>
+  <para style="p">
+    <verse number="29-30" style="v" />Yesus nae, “Au nau afada ei ae leo ia: hatahori mana tungga Au, fo laꞌo ela ndia ina-aman, kaꞌa-fadin, anan nara, osi-lutun, ue-osan, ma basa uma oe-isin lalaꞌen, fo neu tui-bengga Manetualain Hara Lii Malolen sudi nai bee, neu ko ana simbo falik losa lipa laꞌe natun esa. Basa hata fo ana laꞌo elak kara raa, neu ko ana simbo falik manahetak. Ma neu ko ana oo hambu tuni-ndenik, nahuu ana tungga Au. Tehuu neu dae-bafok fai mateꞌen, neu ko ana nasoda nakandoo no Manetualain. Naa, babalan ndian ena. <verse number="31" style="v" />Masaneda, ee! Hatahori fo mana tao aon leo hatahori moꞌo-inahuuk, tungga Manetualain duduꞌan, neu ko ana dadi neu hatahori kadiꞌin lenak. Tehuu hatahori fo mana tao aon leo hatahori kadiꞌik, tungga Manetualain duduꞌan, neu ko ana dadi neu hatahori moꞌo-inahuuk.”<note caller="+" style="x"><char style="xo" closed="false">10:31:</char><char style="xt" closed="false">Mateos 20:16; Lukas 13:30</char></note></para>
+  <para style="s1">Lamatuak Yesus nafada laꞌe katelun ena laꞌe-neu Ndia mamaten</para>
+  <para style="r">(Mateos 20:17-19; Lukas 18:31-34)</para>
+  <para style="p">
+    <verse number="32" style="v" />Faik naa, Yesus asa laꞌo reni Yerusalem reu, Ana nesik mata. Ndia ana nuni kasalahunu duan nara ro hatahori laen nara laꞌok tunggan. Ara bei rasaneda Ndia kokolan fai maneuk kara nae, hatahori nae tao nisan nai Yerusalem. De ara pangganaa ma ramataꞌu. Yesus namanene nala naa, boe ma Ana nanggou nala ana nunin nara mesa kasa, de nafada seluk bali hata fo hatahori nae tao neun nai Yerusalem. <verse number="33" style="v" />Ana nafada nae, “Ei nenene, ee! Hatematak ia ita teni Yerusalem teu. Au ia, Hatahori Dae-bafo Isi-isik. Tehuu nai naa ara seꞌo heni Au, neu malangga anggama malanggan nara ma meser anggamar. Basa de ara raketu hukun mates neu Au. Boe ma ara fee heni Au uni hatahori laen fo ta mana malela Manetualain uu. <verse number="34" style="v" />Boe ma ara rakamamaek Au. Ara pura ambe neu Au. Ara poko-femba rakalulutu Au ao-mbaang. Basa dei fo ara tao risa Au. Memak Au mate tetebes. Tehuu neu bei-nesan, Au asoda fali numa mamates mai.”<note caller="+" style="f"><char style="fr" closed="false">10:34:</char><char style="ft" closed="false">Nai dedeꞌa Yunani, ara mulai reke numa: faik ia (= esa), beꞌe-mai (= dua), bei-nesak (= telu), fai kahaan (= haa). Dadi nai dedeꞌa Yunani, μετὰ τρεῖς ἡμέρας </char><char style="it">(meta treis hēmeras)</char> “nai fai katelun” sosoan nai dedeꞌa Tii, ndia “bei-nesan”. Masaneda, nahuu Lamatuak Yesus maten nai fai limak (reken esa). Beꞌe-mai ndia fai neek (reken dua), Lamatuak Yesus nai rates dale. Bei-nesan, ndia fai menggu (reken telu), Lamatuak Yesus nasoda fali numa mamaten mai. Dadi tungga ita rereke fain, na, Ana mate leꞌodaek dua, boe ma Ana nasoda fali numa mamaten mai.</note></para>
+  <para style="s1">Yakobis no Yohanis roke dadi neu hatahori moꞌo-inahuuk</para>
+  <para style="r">(Mateos 20:20-28)</para>
+  <para style="p">
+    <verse number="35" style="v" />Basa boe ma, Yakobis ma Yohanis, ndia Sabadeus anan nara reni Yesus reu. Ara rafada rae, “Papa Meser! Ai parluu Papa.”</para>
+  <para style="p">
+    <verse number="36" style="v" />Yesus natane sara nae, “Ei parluu hata?”</para>
+  <para style="p">
+    <verse number="37" style="v" />Ara raselu rae, “Talo ia, Papa! Neu ko mete ma Papa nangggatuuk toꞌu parenda ena, na, ai moke-hule Papa fo fee ai kadera nenggetuuk, esa neu Papa boboa konan, ma esa neu Papa boboa kiin, fo ai oo toꞌu parenda boe.”</para>
+  <para style="p">
+    <verse number="38" style="v" />Yesus naselu nae, “Ei dua ngga ia ta bubuluk hata fo ei mokek. Au ia, neu ko hambu doidosok noꞌuk ka. De talo bee? Ei duꞌa mae, ei oo bisa mabeꞌi lemba-masaa doidosok naa sama-sama mia Au losa mate boe, do?”<note caller="+" style="x"><char style="xo" closed="false">10:38:</char><char style="xt" closed="false">Lukas 12:50</char></note></para>
+  <para style="p">
+    <verse number="39" style="v" />Ara raselu rae, “Ai bisa, Papa!”</para>
+  <para style="p">Yesus bala sara bali nae, “Memak, neu ko ei oo lemba-masaa doidosok naa sama leo Au boe. <verse number="40" style="v" />Tehuu see ndia nanggatuuk nai Au boboa kiin do Au boboa konan, Au ta ndia aketu naa. Manetualain ndia naena haak fo naketu. Ana naketu memak ena, see ndia nanggatuuk nai mamanak naa.”</para>
+  <para style="p">
+    <verse number="41" style="v" />Neu ana nuni laen nara ramanene rala Yakobis no Yohanis roke talo naa, boe ma ara ramanasa. <verse number="42" style="v" />Basa boe ma Yesus nanggou nala basa sara, de Ana nae, “Talo ia! Ei bubuluk ena, hetu? Hatahori moꞌo-inahuuk fo mana toꞌu parenda nasiꞌe tuni-ndeni rau-inggun nara, losa ara ta bisa rakaundak rala. Ma malangga nusak kara fo ta mana malela Manetualain, ara fee parenda lena-lenak, losa rau-inggun nara ta bisa botik rala langgan nara. <verse number="43" style="v" />Tehuu ei ta bole tao talo naa! See numa ei mai nau dadi neu hatahori moꞌo-inahuuk, na, ana muste dadi sama leo hatahori neondak fo naono-lalau hatahori laen.<note caller="+" style="x"><char style="xo" closed="false">10:43:</char><char style="xt" closed="false">Lukas 22:25-26</char></note> <verse number="44" style="v" />Ma see ndia nau dadi neu malanggan, na, ana muste tao aon leo ata-dato.<note caller="+" style="x"><char style="xo" closed="false">10:44:</char><char style="xt" closed="false">Mateos 23:11; Markus 9:35; Lukas 22:26</char></note> <verse number="45" style="v" />Au, Hatahori Dae-bafo Isi-isik ia ta mai fo hatahorir raono-lalau Au. Tehuu Au mai fo aono-lalau hatahori noꞌuk ka. Au mai fo fee Au sodang katematuan, fo tefa-soi ala hatahori noꞌuk ruma sala-singgon nara mai.”</para>
+  <para style="s1">Lamatuak Yesus tao nahai hatahori pokek</para>
+  <para style="r">(Mateos 20:29-34; Lukas 18:35-43)</para>
+  <para style="p">
+    <verse number="46" style="v" />Yesus no ana nunin nara ma hatahori noꞌun seli losa kota Yeriko. Neu ara rae laꞌo rakandoo, te hatahori pokek esa nanggatuuk fo hule-hule numa dalak tatain. Naden Bartimeos, ndia papa Timeos anan. <verse number="47" style="v" />Neu ana namanene nae, mana laꞌok nesik naa, ndia Yesus numa Nasaret mai, boe ma ana bolu nahere nae, “Yesus, Dauk tititi-nonosin, ee! Ai mahani a neu Papa dook ka ena. Kasian neu au dei!”</para>
+  <para style="p">
+    <verse number="48" style="v" />Hatahorir ramanene ana bolu talo naa, boe ma ara kaꞌin rae, “Weeh! Nenee!”</para>
+  <para style="p">Tehuu ana boe kii-bolu nahere nae, “Yesus! Dauk tititi-nonosin, ee! Kasian neu au dei!”</para>
+  <para style="p">
+    <verse number="49" style="v" />Boe ma Yesus nambarii taak, de nae, “Mian mai dei!”</para>
+  <para style="p">Boe ma ara reu, de rafadan rae, “O nenee leo! Papa Meser noke o. Mai leo!”</para>
+  <para style="p">
+    <verse number="50" style="v" />Bartimeos namanene talo naa, boe ma ana piru heni lafan, de nambadeik lai-laik neu natonggo no Yesus.</para>
+  <para style="p">
+    <verse number="51" style="v" />Yesus natane nae, “O hii hata?”</para>
+  <para style="p">Hatahori pokek naa naselu nae, “Papa, ee! Au oke-hule fo au bisa mete-ita.”</para>
+  <para style="p">
+    <verse number="52" style="v" />Yesus nafada seluk kana bali nae, “Huu o mamahere mae, Au bisa tao ahai o, de hatematak ia o hai ena. Muu leo!”</para>
+  <para style="p">Boe ma Bartimeos matan mete-nita tutik kana leo. Basa boe ma ana laꞌo tungga neu nafuli Yesus.</para>
+  <chapter number="11" style="c" />
+  <para style="s1">Lamatuak Yesus asa maso reni Yerusalem reu, ma basa hatahori koa-kion sama leo hatahori moꞌo-inahuuk</para>
+  <para style="r">(Mateos 21:1-11; Lukas 19:28-40; Yohanis 12:12-19)</para>
+  <para style="p">
+    <verse number="1" style="v" />Neu ara sangga deka kota Yerusalem, boe ma ara losa nggorok dua, ndia Betfage ma Betania, rai letek Setun tatain.<note caller="+" style="f"><char style="fr" closed="false">11:1:</char><char style="ft" closed="false">Letek naa ara foin nade ‘Setun’, nahuu nai naa hambu osi ai huuk setun noꞌuk ka, fo ara rumu rala minan numa boan mai. Letek Setun naa nai rarain doon kilo esa numa Yerusalem mai.</char></note> Numa naa, Yesus asa hahae taak. Boe ma Ana nadenu ana nunin dua laꞌo rakahuluk. <verse number="2" style="v" />Ana helu sara nae, “Ei dua ngga makahuluk, meni nggorok naa miu. Mete ma ei maso, neu ko ei mete-mita banda keledei esa anan neni paꞌak nai naa. Hatahorir bei ta saꞌe ritan. Miu sefi heni talin fo leꞌa menin ia mai. <verse number="3" style="v" />Tehuu mete ma hambu hatahori natane ei nae, ‘Tao hata de ei sefi meni keledei naa?’ Na, ei maselun mae, ‘Ai Lamatuan nae paken. Mete ma Ana pake basa, neu ko Ana haitua fali memak kana.’ ”</para>
+  <para style="p">
+    <verse number="4" style="v" />Boe ma hatahori kaduak kara raa reu, de mete-rita keledei naa anan neni paꞌak nai uma esa bebelan, nai dalak tatain. Boe ma ara sefi heni talin, de leꞌa renin. <verse number="5" style="v" />Tehuu hatahorir fo mana rambariik ruma naa ratane rae, “Weeh! Tao hata de ei sefi meni hatahori keledein?”</para>
+  <para style="p">
+    <verse number="6" style="v" />Boe ma ara raselu rae, “Ai Lamatuan nae paken. Mete ma Ana pake basa, neu ko ai meni fali memak kana!” Boe ma hatahorir raa ela sara leꞌa reni keledei naa. <verse number="7" style="v" />Ara leꞌa renin neni Yesus neu. Boe ma ara bela lafan nara neu keledei naa lain, de Yesus saꞌen.</para>
+  <para style="p">
+    <verse number="8" style="v" />Neu ara sangga maso kota dale reu, boe ma hambu hatahori noꞌuk ka haꞌi rala lafan nara ma ndae arun nara, de ara tao sara reu dalak lain. Hambu ketuk reu tati rala mbua sina doon nara<note caller="+" style="f"><char style="fr" closed="false">11:8:</char><char style="ft" closed="false">Markus susuran huun surak nae ‘ndanan nara’. Tehuu ita bubuluk nai Yohanis 12:13 nae, naar sira mbua sina doon nara.</char></note> numa dalak tatain fo ara nggenggela sara reu dalak taladan. No dalak naa, ara tao tanda rae, sira soru Lamatuak Yesus no hada-horomatak. Sama leo ara rasiꞌe soru hatahori moꞌo-inahuuk kara. <verse number="9" style="v" />Boe ma hambu hatahori ketuk laꞌok rakahuluk resik Yesus matan, ma ketuk laꞌok tungga dean. Ara mulai eki rae,</para>
+  <para style="q1">
+    <char style="it">“Hosana!</char> Ita koa-kio Manetualain!<note caller="+" style="f"><char style="fr" closed="false">11:9:</char><char style="ft" closed="false">Sira dedeꞌa Aram nae, </char><char style="it">‘Hosana’</char>. Lele uluk sosoa-ndandaan nae, ‘ana tao nasoi-nasoda’. Tehuu nai Lamatuak Yesus tembo-lelen, ara rasiꞌe pake dedeꞌa deꞌek naa, fo koa-kio Manetualain.</note></para>
+  <para style="q2">Manetualain fee babaꞌe-babatik neu hatahori fo ana mai pake Manetualain naden,</para>
+  <para style="q3">huu Manetualain nadenun mai ena!<note caller="+" style="x"><char style="xo" closed="false">11:9:</char><char style="xt" closed="false">Sosoda Kokoa-kikiok kara 118:26</char></note></para>
+  <para style="q1">
+    <verse number="10" style="v" />
+    <char style="it">Hosana!</char> Ita koa-kio Manetualain!</para>
+  <para style="q2">Huu Manetualain nae nambadedeik falik mane Dauk parendan!</para>
+  <para style="q1">
+    <char style="it">Hosana!</char> Ita koa-kio Manetualain!</para>
+  <para style="q2">Huu Manetualain nanggatuuk toꞌu parenda ena nai lalai fo demak mateꞌen!”</para>
+  <para style="p">
+    <verse number="11" style="v" />Yesus asa losa kota dale, boe ma ara maso reni Manetualain Uma Huhule-haradoi Ina-huun bebelan reu. Boe ma Yesus mete natalolole ndule basa uma naa nanalan. Tehuu sangga makiuk ena, de ara fali reni nggoro Betania reu.</para>
+  <para style="s1">Lamatuak Yesus parenda ai huuk esa fo ana ta bisa naboa ena</para>
+  <para style="r">(Mateos 21:18-19)</para>
+  <para style="p">
+    <verse number="12" style="v" />Neu beꞌe-mai huhua anan, boe ma ara kalua numa Betania mai, de ara maso fali reni kota Yerusalem reu. Tehuu neu ara bei laꞌok numa dalak, boe ma Yesus nameda ndoe. <verse number="13" style="v" />Ana mete-nita ai huuk esa numa dalak tatain. Hatahorir rasiꞌe raꞌa boan.<note caller="+" style="f"><char style="fr" closed="false">11:13:</char><char style="ft" closed="false">Dedeꞌa Indonesia pake dedeꞌa deꞌek nae ‘Ai huu kaak’, numa dedeꞌa Yunani </char><char style="it">sukē</char>mai. Tehuu Susura Malalaok natudu ai huu kaak fo hatahorir rasiꞌe selen ma raꞌa boan nai Israꞌel. Nai Indonesia dulu, hatahorir ta selen ma ta raꞌa ai naa boan. De ‘ai huu kaak’ nai Susura Malalaok dale ta sama no ita ai huu kaak manai ia.</note> De Yesus laꞌok deka-deka neni ai huuk naa neu fo nae mete sudik kaboak, do taa. Neu Ana losa ai huuk naa, Ana ta mete-nita boak esa boe na, Ana mete-nita kada ai huuk naa doon. Huu memak fai neboan bei ta losa. <verse number="14" style="v" />Boe ma Yesus parenda ai huuk naa nae, “Huu o ta bisa fee o boan mai Au, de mulai numa hatematak ia neu o ta bisa fee o boan neu hatahori laen ena!”</para>
+  <para style="p">Ana nunin nara ramanene, Ana nahara berak talo naa.</para>
+  <para style="s1">Lamatuak Yesus maso neni Manetualain Uma Huhule-haradoi Ina-huun neu, de ofe heni pasar numa naa</para>
+  <para style="r">(Mateos 21:12-17; Lukas 19:45-48; Yohanis 2:13-22)</para>
+  <para style="p">
+    <verse number="15" style="v" />Basa boe ma ara laꞌok rakandoo losa Yerusalem, de Yesus maso seluk neni Manetualain Uma Huhule-haradoi Ina-huun neu. Numa Uma Huhule-haradoi Ina-huuk naa bebelan, hatahori taon dadi neu pasar, fo ara raseseꞌo mbui lunda sinar, ndia hatahori paken dadi neu tunu-hotuk soa-neu hule-haradoik. Yesus mete-nita talo naa, boe ma Ana neu husi-mbuu kalua heni sara. Ana fae nggari heni basa meir fo ara pake tuka doik, ma fae nalengga heni basa banggur fo ara pake raseseꞌo mbuik kara. <verse number="16" style="v" />Boe ma Ana kaꞌi-ore basa hatohori fo ta bole reni bua-baꞌun nara fo laꞌok tepa tungga Uma naa bebelan bali. <verse number="17" style="v" />Boe ma Ana nanori sara nae, “Ei bubuluk memak ena hata fo Manetualain mana toꞌu dedeꞌan nara surak ena rae, ‘Au ambadedeik Au Umang ia fo basa hatahori nusa-nusak kara mai hule-haradoi nai ia.’ Tehuu ei tao Uma ia dadi neu naꞌo manu-meor mamana nekebuan!”<note caller="+" style="x"><char style="xo" closed="false">11:17:</char><char style="xt" closed="false">Yesaya 56:7; Yermia 7:11</char></note></para>
+  <para style="p">
+    <verse number="18" style="v" />Neu malangga anggama Yahudir malanggan nara ma meser anggamar ramanene Yesus tao talo naa ena, boe ma ara rasakele neun. De ara mulai sangga dalak fo rae tao risan. Tehuu ara oo ramahia boe, nahuu hatahori noꞌuk ka hii ralan seli neu Ndia nenorin.</para>
+  <para style="p">
+    <verse number="19" style="v" />Neu ledo mulai tesa ena, boe ma Yesus asa kalua numa kota Yerusalem mai, fo fali reu sunggu nai nggorok Betania.</para>
+  <para style="s1">Mete ma ita tamahere tebe-tebe neu Manetualain, na, neu ko Ana fee hata fo ita tokek</para>
+  <para style="r">(Mateos 21:20-22)</para>
+  <para style="p">
+    <verse number="20-21" style="v" />Neu beꞌe-mai huhua anan, boe ma ara fali reni Yerusalem reu bali. Neu ara bei laꞌok numa dalak, ara resik ai huuk naa, fo afik ka Yesus kokolak neun. Ana nunin nara heran bali-bali, nahuu ai huuk naa mate namatuu losa okan nara ena. Boe ma Petrus nasaneda Yesus kokolan afik ka naa. Basa boe ma ana nafada nae, “Papa! Mete sudik! Ai huuk naa fo afik ka Papa nakatoon naa, maten ena!”</para>
+  <para style="p">
+    <verse number="22" style="v" />Boe ma Yesus naselu nae, “Memak tetebes! Sadi ei oo mamahere tebe-tebe neu Manetualain leo naak boe. <verse number="23" style="v" />Mete ma ei mamahere tebe-tebe, na, ei bisa madenu letek esa fo lali neni tasi neu. Dei fo Manetualain lali heni letek naa, sadi ei nemeheherem boso bibiak! Ei muste mamahere tebe-tebe neu Manetualain.<note caller="+" style="x"><char style="xo" closed="false">11:23:</char><char style="xt" closed="false">Mateos 17:20; 1 Korentus 13:2</char></note> <verse number="24" style="v" />Boso lilii-ndondou, ee! Sadi ei mamahere tebe-tebe mae, Manetualain bisa nabeꞌi fee hata fo ei mokek, neu ko Ana taon fee ei! <verse number="25" style="v" />Tehuu mete ma hambu hatahori esa hule-haradoi, naa te dalen ta neulauk no hatahori laen, na, ana muste malole fali no hatahori naa dei. Talo naa dei fo ei Amam manai nusa tetuk do inggu temak, koka heni ei sala-singgom. <verse number="26" style="v" />[Mete ma hambu numa ei mai bei nambeda dalek, ma ta nau fee ambon neu hatahori, neu ko ei Amam manai nusa tetuk do inggu temak oo ta nau lilii heni ei sala-singgom mara boe.”]<note caller="+" style="f"><char style="fr" closed="false">11:26:</char><char style="ft" closed="false">Susura dedeꞌa Yunani huuk fo lasin lenak ta surak lalanek ka-26 ia.</char></note> <note caller="+" style="x"><char style="xo" closed="false">11:26:</char><char style="xt" closed="false">Mateos 6:14-15</char></note></para>
+  <para style="s1">Ara rakaseseluk dedeꞌak ro Lamatuak Yesus laꞌe-neu Ndia haak</para>
+  <para style="r">(Mateos 21:23-27; Lukas 20:1-8)</para>
+  <para style="p">
+    <verse number="27" style="v" />Basa boe ma ara laꞌo rakandoo. Losa Yerusalem, boe ma ara maso reni Manetualain Uma Huhule-haradoi Ina-huun reu bali. Neu ara maso losa Uma bebelan, boe ma malangga anggama Yahudi malanggan nara, meser anggamar, ma lasi-lasi hadak Yahudir mai, <verse number="28" style="v" />fo ratane Yesus rae, “See ndia nadenu O mai tao nemuek numa ia ndia afik ka? See ndia fee O haak?”</para>
+  <para style="p">
+    <verse number="29" style="v" />Tehuu Yesus bubuluk ara sangga dalak fo rae rakatutudak Ndia. Boe ma Ana bala nae, “Au oo ae atane ei boe. Ei maselu Au dei, dei fo Au aselu ei. <verse number="30" style="v" />Au ae atane talo ia: ei basa ngga malela Yohanis, Mana Saranik naa, hetu? See ndia feen haak fo ana sarani hatahorir? Manetualain, do hatahori dae-bafok?”</para>
+  <para style="p">
+    <verse number="31" style="v" />Boe ma ara duduꞌa reu-mai, ma rakokola aok rae, “Awii! Ikek nala ita ia ena, ma! Huu mete ma ita taselu tae, ‘Manetualain ndia feen haak’, neu ko Ana bala nae, ‘Mete ma talo naa, tao hata de ei ta mamahere Yohanis?’ <verse number="32" style="v" />Ma ita oo ta bisa tae, ‘Hatahori dae-bafok ndia nadenun.’ Neu ko basa hatahori ramue, nahuu ara ramahere rae, Yohanis naa, Manetualain mana toꞌu dedeꞌan.”</para>
+  <para style="p">
+    <verse number="33" style="v" />De ara raselu rae, “Ai ta bubuluk!”</para>
+  <para style="p">Boe ma Yesus naselu seluk bali nae, “Mete ma talo naa, na, Au oo ta nau afada boe ae, see ndia nadenu Au.”</para>
+  <chapter number="12" style="c" />
+  <para style="s1">Lamatuak Yesus tui lololek laꞌe-neu hatahori mana maue osi anggor</para>
+  <para style="r">(Mateos 21:33-46; Lukas 20:9-19)</para>
+  <para style="p">
+    <verse number="1" style="v" />Basa boe ma Yesus nafada seluk bali neu malangga anggama Yahudi malanggan nara, meser anggamar, ma lasi-lasi hadak Yahudir. Ana pake lololek nae, “Hatahori esa neu tao osi neu daen faa, fo sangga sele ai anggor. Basa de ana mbaꞌa eko-feon. Ma ana tao baak fo nae natanee anggor oen. Ana oo nambaririik mamana nenea demak esa boe. Basa de ana fee osi naa neu hatahori laen fo ara raue ma rabaꞌe buna-boan nara roon. Boe ma ana laꞌo neni nusa feꞌek neu.<note caller="+" style="x"><char style="xo" closed="false">12:1:</char><char style="xt" closed="false">Yesaya 5:1-2</char></note></para>
+  <para style="p">
+    <verse number="2" style="v" />Losa fai ketu anggor boan, boe ma tenu daek naa nadenu ndia hatahori mana maue-osan esa neni hatahori mana maue osir raa neu, fo noke ndia babaꞌen. <verse number="3" style="v" />Tehuu neu ana losa, mana maue osir raa humu ralan, de ara popokon. Boe ma ara radenun fali no lima rouk.</para>
+  <para style="p">
+    <verse number="4" style="v" />Basa boe ma tenu daek nadenu ndia hatahori mana maue-osan esa bali. Tehuu mana maue osir raa popoko hatahori naa langgan losa hinak kara. Boe ma ara rakamamaek kana ma ara husi henin. <verse number="5" style="v" />Boe ma tenu daek naa nadenu seluk ndia hatahori mana maue-osan laen bali. Tehuu ara hala risan. Leo mae ara tao talo bee oo, tenu daek naa kada nadenu ndia hatahori mana maue-osan neu nakandoo boe. Tehuu mana maue osir raa popoko ketuk, ma hala risa ketuk. <verse number="6" style="v" />Hatematak ia ela kada hatahori esa, ndia tenu daek ana tou kisen, fo ana susuen mateꞌen. Huu ana ta hambu dalak seluk ena, de nadenu kada kanak naa neu. Ana duꞌa nae, ‘Mete ma au adenu au ana heli-heling ndia neu, neu ko ara simbon no malole, ma ara ramanene neun.’</para>
+  <para style="p">
+    <verse number="7" style="v" />De ana nadenu anan neu. Tehuu mana maue osir raa mete-rita kanak naa mai, boe ma ara rakokola aok rae, ‘Woi! Ei mete dei! Tou lasik nadenu ana heli-helin mai ena! Mete ma tou lasik maten, na, kanak ia ndia simbo nala basa pusakar raa lalaꞌen. Mai fo ita hala tisan, mita fo ita laꞌe tala ndia pusakan ia.’ <verse number="8" style="v" />Boe ma ara rame-rame humu ralan, de ara hala risan. Basa naa ara koꞌo rala ao-mbaa mamaten, de ara nggarin neni osi dea neu. Lololek ia losa kada naa.”</para>
+  <para style="p">
+    <verse number="9" style="v" />Basa boe ma Yesus natane hatahori moꞌo-inahuuk kara nae, “Tungga ei hahambum mara, na, tenu daek tao mana maue osir raa talo bee? Tungga Au, na, neu ko tenu daek mai fo hala nisa basa mana maue osir raa. Basa naa, ana fee osi naa neu hatahori laen fo naue ma rabaꞌe buna-boan.</para>
+  <para style="p">
+    <verse number="10" style="v" />Ita basa ngga lees tita Manetualain Susura Malalaon ena nae,</para>
+  <para style="q1">‘Hambu batu esa tukan nara nggari henin ena.</para>
+  <para style="q2">Tehuu hatematak ia, batu naa dadi neu batu netehuuk ena.</para>
+  <para style="q1">
+    <verse number="11" style="v" />Manetualain mesa kana ndia here nalan, de nanggatutuuk batu naa.</para>
+  <para style="q2">Huu naa de ita mete-titan lolen seli!’ ”<note caller="+" style="x"><char style="xo" closed="false">12:11:</char><char style="xt" closed="false">Sosoda Kokoa-kikiok kara 118:22-23</char></note></para>
+  <para style="p">
+    <verse number="12" style="v" />Hatahori moꞌo-inahuuk kara raa ralela ralak kana rae, Yesus pake lololek naa ndee laꞌe sira. Ara tetuk sama leo mana maue osir bebeik kara raa. Basa boe ma ara mulai sangga dalak fo rae humu Yesus. Tehuu ara ramahia hatahori noꞌuk kara fo mana hii Yesus nenorin. De ara laꞌo ela Yesus leo.</para>
+  <para style="s1">Hatahori rae ike Lamatuak Yesus pake dalak bae bea</para>
+  <para style="r">(Mateos 22:15-22; Lukas 20:20-26)</para>
+  <para style="p">
+    <verse number="13" style="v" />Basa boe ma hatahori Yahudir moꞌo-inahuun nara radenu hatahori Farisi hida ro Herodes partein hatahorin hida bali reu rakaseseluk dedeꞌak ro Yesus fo ara rae iken. <verse number="14" style="v" />Ara mai de rakaseseluk dedeꞌak ro Yesus rae, “Papa Meser! Ai basa ngga bubuluk Papa dalen ndoos, ma ta mana nalela pepeke-lelekok. Papa kada mete hatahori dalen. Papa oo nafada Manetualain hihii-nanaun no manggaledok boe, nahuu Papa ta mana mete matak. De hatematak ia, ai nau matane dedeꞌak esa. Tungga ita anggama Yahudi hohoro-lalanen, ndondoon naa ita bae bea neu man-parenda Roma mane ina-huun,<note caller="+" style="f"><char style="fr" closed="false">12:14:</char><char style="ft" closed="false">Hatahori Roma mane ina-huun, roken rae ‘Keser’.</char></note> do taa?”</para>
+  <para style="p">
+    <verse number="15" style="v" />Tehuu Yesus bubuluk nae, ara rae ike Ndia naa ena fo Ndia kokolak laban man-parenda Roma. Boe ma Yesus naselu no nahere haran nae, “Tao hata de ei nau ike Au no dedeꞌak naa! Matudu sudik Au doi fulak esa dei!”</para>
+  <para style="p">
+    <verse number="16" style="v" />Boe ma ara loo fee Yesus doi fulak esa. Yesus haꞌi nalan, de ana namumulan. Basa boe ma Ana natane sara nae, “Nggambar ia, see matan? Ma ia see naden?”</para>
+  <para style="p">Boe ma ara raselu rae, “Naa, man-parenda Roma mane ina-huun!”</para>
+  <para style="p">
+    <verse number="17" style="v" />Boe ma Yesus nae, “Mete ma leo naa, na, ei miu fee man-parenda hata fo man-parenda haak. Ma fee Manetualain hata fo Manetualain haak.”</para>
+  <para style="p">Ara ramanene rala Yesus naselu talo naa, boe ma basa sara heran bali-bali, huu Ana nafada ndaa, na. Huu naa de ara ta bisa ike rala sana.</para>
+  <para style="s1">Nenorik laꞌe-neu hatahori mates nasoda fali numa mamaten mai, ma bei hambu dedeꞌa sasaok soa-neu hatahori nai nusa tetuk do inggu temak, do taa?</para>
+  <para style="r">(Mateos 22:23-33; Lukas 20:27-40)</para>
+  <para style="p">
+    <verse number="18" style="v" />Hambu partei anggama laen esa, fo hatahorir roken rae, partei Saduki. Ara fee nenorik rae, hatahori mates ta bisa nasoda fali numa mamaten mai. Laꞌe esa, hambu hatahori Saduki hida oo, mai fo rae ike Yesus boe. Ara kokolak ro Yesus rae,<note caller="+" style="x"><char style="xo" closed="false">12:18:</char><char style="xt" closed="false">Nedenuk kara Tutuin 23:8</char></note> <verse number="19" style="v" />“Papa Meser! Baꞌi Musa surak ela fee ita dala-hadak ia nae: Mete ma touk esa mate laꞌo ela saon, ma anak taa, na, touk naa fadin muste sao nala ina falu naa, mita fo ana fee tititi-nonosik soa-neu kaꞌan mana matek naa ena.<note caller="+" style="x"><char style="xo" closed="false">12:19:</char><char style="xt" closed="false">Tui Seluk laꞌe-neu Dala Masodak 25:5</char></note> <verse number="20" style="v" />Memak Musa fee nenorik talo naa. Tehuu ai nau matane talo ia: hambu touk hitu kaꞌa-fadik kara. Uluk sao nakahuluk, boe ma maten, tehuu anak taa. <verse number="21" style="v" />Boe ma fadik mana tunggan, sao nasafali ina falu naa. Ta dook ka, ana oo mate boe, ma anak taa. Leo naak oo no fadik katelun boe. Ana sao nala ina falu naa, tehuu ana mate, ma anak taa. <verse number="22" style="v" />Talo naa nakandoo losa fadi muri anak oo, maten boe. Basa boe ma ina falu naa maten.</para>
+  <para style="p">
+    <verse number="23" style="v" />Dadi hatematak ia, ai nau matane talo ia: inak naa sao nita no touk hitu ena. Neu ko neu dae-bafok fai mateꞌen, Manetualain nasoda falik hatahori mates sara, inak naa dadi neu see saon numa touk kahituk kara mai, ou?”</para>
+  <para style="p">
+    <verse number="24" style="v" />Boe ma Yesus naselu nae, “Mete ma ei matane talo naa, sosoan-ndandaan nae, ei ta malela tebe-tebe Manetualain Susura Malalaon isin. Ma ei oo ta malela Manetualain koasan boe. Dadi eir ia sala tebe-tebe ena!</para>
+  <para style="p">
+    <verse number="25" style="v" />Nenene, ee! Talo ia: ta hambu dedeꞌa sasaok nai nusa tetuk do inggu temak. Basa hatahori mates lalaꞌen fo Manetualain tao nasoda falik kasa, ta hambu esa sao bali. Leo naak oo, Manetualain atan nara marai nusa tetuk do inggu temak ta sao boe. <verse number="26" style="v" />Ma Au oo nau kokolak laꞌe-neu hatahori mates bisa nasoda fali numa mamaten mai, do taa boe. Baꞌi Musa surak laꞌe-neu ai huu anak fo aꞌi naꞌan, tehuu ta kade sana. Ei masaneda tutuik naa, do taa? Neu aꞌi mbila numa ai huuk naa, Manetualain nafada baꞌi Musa nae, ‘Au ia, Manetualain numa o baꞌim mara mai, sira baꞌi Abraham, baꞌi Isak, ma baꞌi Yakob. Basa sara rakaluku-rakatele rakandoo reu Au losa hatematak ia.’<note caller="+" style="x"><char style="xo" closed="false">12:26:</char><char style="xt" closed="false">Kalua numa Masir mai 3:6</char></note> <verse number="27" style="v" />De ita bubuluk tae, ita baꞌin nara raa mates sara dook ka ena. Tehuu Manetualain nafada ena nae, Ndia bei dadi neu sira Lamatuan, huu naa de ita bubuluk tae, ara rasoda fali ena. Dadi leo mae hatahorir mate ena oo, ara rasoda fali numa mamates mai boe. Memak hatahori masodak ndia rakaluku-rakatele neu Manetualain, ta hatahori mates, hetu? Dadi mete ma ei toꞌu makandoo nenorik naa mae, hatahori mates ta nasoda fali numa mamaten mai, memak ei sala malan seli naa ena!”</para>
+  <para style="s1">Sue-lai neu Manetualain ma sue-lai neu hatahori</para>
+  <para style="r">(Mateos 22:34-40; Lukas 10:25-28)</para>
+  <para style="p">
+    <verse number="28" style="v" />Faik naa, neu Yesus nanggatuuk kola-kola no partei Saduki hatahorin nara, hambu meser anggama esa tungga namanenen. Meser anggama naa duꞌa nae, Yesus naselu hatahori Sadukir netanen nara no malole ena. Boe ma ana natane Yesus nae, “Papa! Au nau atane talo ia: ita dala-hadan hohoro-lalanen, ma anggama parendan, noꞌun seli. Numa basa parendar fo maruma baꞌi Musa mai naa, bee ndia nenenin lenak mateꞌen?”</para>
+  <para style="p">
+    <verse number="29" style="v" />Yesus naselu nae, “Parenda fo nenenin lenak mateꞌen nai Manetualain Susura Malalaon dale naa nae talo ia:</para>
+  <para style="q1">‘Basa hatahorir marai Israel! Ei nenene matalolole!</para>
+  <para style="q1">Manetualain naa, memak ita Lamatuan,</para>
+  <para style="q2">ma ita Mana Parenda Mana Koasan.</para>
+  <para style="q3">Ta hambu seluk laen, kada Ndia mesa kana ena.</para>
+  <para style="q1">
+    <verse number="30" style="v" />De ei muste sue-lai neun <char style="it">lena</char> heni basa-basan.</para>
+  <para style="q2">Huu naa de ei muste hii malan seli neun,</para>
+  <para style="q2">malela Ndia,</para>
+  <para style="q2">ma maue-osa fafandek lima-eim mara fo tungga Ndia hihii-nanaun.’<note caller="+" style="x"><char style="xo" closed="false">12:30:</char><char style="xt" closed="false">Tui Seluk laꞌe-neu Dala Masodak 6:4-5</char></note></para>
+  <para style="p">
+    <verse number="31" style="v" />Ma parenda kaduan nae talo ia:</para>
+  <para style="q1">‘O muste sue hatahori laen nara, sama leo o sue o ao heli-helim.’</para>
+  <para style="p">Parenda kaduak kara ia nenenin lenak mateꞌen. Ta hambu parenda laen bali fo nenenin lena heni parenda kaduak kara ia.”<note caller="+" style="x"><char style="xo" closed="false">12:31:</char><char style="xt" closed="false">Malangga Anggamar Hohoro-lalanen 19:18</char></note></para>
+  <para style="p">
+    <verse number="32" style="v" />Basa boe ma meser anggama naa kokolak seluk no Yesus nae, “Memak Papa kokolan naa, tetebes. Manetualain dadi neu ita Malangga Ina-huun, ma ta hambu Lamatuak laen ena.<note caller="+" style="x"><char style="xo" closed="false">12:32:</char><char style="xt" closed="false">Tui Seluk laꞌe-neu Dala Masodak 4:35</char></note> <verse number="33" style="v" />Ita muste sue-lai Manetualain lena heni basa-basan, losa ita hii talan seli neun, ma ita talela Ndia, ma taue-osa fafandek ita lima-ein nara fo tungga Ndia hihii-nanaun. Ma ita muste sue basa hatahorir sama leo ita sue ita ao-ina heli-helin. Ita tao talo naa, na, Manetualain namahoko nalan seli lena heni ita tungga kada anggama hohoro-lalanen. Naa, lolen lena numa kada ita tao banda tunu-hotuk, do fee bua-baꞌuk laen neu Ndia.”<note caller="+" style="x"><char style="xo" closed="false">12:33:</char><char style="xt" closed="false">Hosea 6:6</char></note></para>
+  <para style="p">
+    <verse number="34" style="v" />Yesus namanene nala ana naselu talo naa, boe ma Ana duꞌa nae, meser anggama naa nalela no malole ena. Boe ma Yesus nae, “O sangga mae dadi muu Manetualain hatahorin ena.”</para>
+  <para style="p">Basa boe ma ta hambu seluk hatahori laen bali nambarani nakaseseluk dedeꞌak no Yesus, te ta hambu hatahori esa senggi Yesus boe na.<note caller="+" style="x"><char style="xo" closed="false">12:34:</char><char style="xt" closed="false">Lukas 10:25-28</char></note></para>
+  <para style="s1">Karistus naa memak mane Dauk tititi-nonosin, ma Ndia oo dadi neu mane Dauk Lamatuan boe</para>
+  <para style="r">(Mateos 22:41-46; Lukas 20:41-44)</para>
+  <para style="p">
+    <verse number="35" style="v" />Yesus bei nanori hatahorir raa nai Manetualain Uma Huhule-haradoi Ina-huun. Boe ma Yesus natane sara nae, “Tungga ei hahambum, na, talo bee? Meser anggamar fee nenorik rae, Karistus naa, ndia Manetualain here memak kana numa lele uluk mai ena. Tungga sira, na, Ndia kada mane Dauk tititi-nonosin. Tehuu naa, ta ndaa. <verse number="36" style="v" />Lele uluk Manetulain Dula-dale Malalaon pake mane Dauk fo ana surak ena nae,</para>
+  <para style="q1">‘Manetualain nafada au lamatuang ena nae,</para>
+  <para style="q2">“Mai fo manggatuuk muu mamana hada-horomatak mateꞌen ia nai Au boboa konang.</para>
+  <para style="q3">Neu ko Au tao ala o musum mara losa ara doꞌor mbali O.’ ”<note caller="+" style="x"><char style="xo" closed="false">12:36:</char><char style="xt" closed="false">Sosoda Kokoa-kikiok kara 110:1</char></note></para>
+  <para style="p">
+    <verse number="37a" style="v" />Numa naa mai, ita bubuluk tae, mane Dauk mesa kana noke Karistus naa nae, ‘Lamatuak’. Sosoa-ndandaan nae, mete ma hatahorir kokolak rae, Karistus naa, kada mane Dauk tititi-nonosin, na, naa ta bei dai. Ana oo dadi neu mane Dauk Lamatuan boe!”</para>
+  <para style="s1">Lamatuak Yesus nae, besa-besa mia meser anggamar pepeko-lelekon</para>
+  <para style="r">(Mateos 23:1-36; Lukas 20:45-47)</para>
+  <para style="p">
+    <verse number="37b" style="v" />Neu Yesus kokolak talo naa, boe ma hatahori noꞌuk ka hii ralan seli nenene neun. <verse number="38" style="v" />Basa boe ma Yesus nafada neu sara bali nae, “Ei muste besa-besa mia meser anggamar. Ara rasiꞌe laꞌo-laꞌo pake badu naruk roroso losa daer, reu ratonggo ro hatahori noꞌuk kara, mita fo hatahorir mete-rita sara, na, rae, ‘Wee! Sira iar, hatahori moꞌo-inahuuk!’ <verse number="39" style="v" />Mete ma ara maso reni uma huhule-haradoik dale reu, do reu raꞌa feta, na, ara soa sangga mamana nenggetuuk neulaun lenak, mita fo hatahori noꞌuk kara mete-rita sara. <verse number="40" style="v" />Tehuu besa-besa! Ara soa pepeko-leleko ina falur fo fonda rala uman nara lalaꞌen. Tehuu nai hatahori noꞌuk kara matan, ara rafuni sira manggaraun ma rambariik hule-haradoi dook ka. Ara nau fo hatahori rae, sira iar, hatahori lolo-laok. Tehuu neu ko Manetualain fee hukun beran lenak neu sara.”</para>
+  <para style="s1">Ina falu hata taak esa mbeda doi kolete moꞌon lenak</para>
+  <para style="r">(Lukas 21:1-4)</para>
+  <para style="p">
+    <verse number="41" style="v" />Basa boe ma Yesus neu nanggatuuk nasare neni mamana kolete manai Manetualain Uma Huhule-haradoi Ina-huun naa neu. Ana mete-nita hatahorir mai mbeda sira doi koleten nara reni mamanan dale neu. Yesus mete-nita hatahori kamasuꞌik kara oo mai mbeda sira doin noꞌun seli numa naa boe. <verse number="42" style="v" />Boe ma ina falu hata taak esa oo mai tungga hule-haradoi boe. Ana mbeda doik seen dua neni mamanak naa neu. Doik naa belin kadiꞌi anan seli.</para>
+  <para style="p">
+    <verse number="43" style="v" />Boe ma Yesus nggape ana nunin nara, de nae, “Ei mete matalolole ina falu hata taak naa dei. Ana mbeda kada doik seen dua, tehuu ana fee baꞌu lena heni basa hatahorir lalaꞌen ena. <verse number="44" style="v" />Basa hatahori laen nara raa fee kolete numa doi sisan nara mai. Tehuu ina falu ia fee basa ndia doin neu Manetualain.”</para>
+  <chapter number="13" style="c" />
+  <para style="s1">Lamatuak Yesus nafada memak laꞌe-neu Uma Huhule-haradoi Ina-huuk ndendefan</para>
+  <para style="r">(Mateos 24:1-2; Lukas 21:5-6)</para>
+  <para style="p">
+    <verse number="1" style="v" />Basa naa, Yesus no ana nunin nara rae laꞌo ela Uma Huhule-haradoi Ina-huuk. Neu ara kalua, boe ma ana nunin esa dudu Uma Huhule-haradoik naa, ma nae, “Papa, ee! Hena Papa mete sudik ia dei. Uma ia lolen seli! Ara tia-totodo rala batu moꞌon nara neulaun seli!”</para>
+  <para style="p">
+    <verse number="2" style="v" />Boe ma Yesus naselu nae, “Uma ia memak malole! Tehuu ta dook ka bali te ara randefa heni basa batun nara lalaꞌen.”</para>
+  <para style="s1">Dae-bafok fai mateꞌen tandan nara</para>
+  <para style="r">(Mateos 24:3-14; Lukas 21:7-19)</para>
+  <para style="p">
+    <verse number="3" style="v" />Basa boe ma Yesus asa reni letek Setun reu fo ranggatuuk ruma mamana mana mbali neni Uma Huhule-haradoi Ina-huuk naa neu. Boe ma ana nunin haa mai, de mesa kasa kokolak ro Yesus. Ana nuni kahaak kara raa sira Petrus, Yakobis, Yohanis ma Anderias. <verse number="4" style="v" />Ara ratane rae, “Papa! Hena Papa mafada seluk Papa kokolan bebeik kara ia dei! Neu faik bee fo fain losa? Boe ma tandan nara leo beek?”</para>
+  <para style="p">
+    <verse number="5" style="v" />Boe ma Yesus naselu nae, “Sadi ei manea matalolole! Fo ei boso hambu kedi-irak. <verse number="6" style="v" />Neu ko hambu hatahori mata-matak kara mai fo femba tenden nara rae, ‘Au ia ndia Karistus, fo Manetualain helu-bartaa memak kana numa lele uluk mai.’ Boe ma ara oo kedi-ira rala hatahori noꞌuk ka boe. <verse number="7" style="v" />Mete ma ei mete-mita hatahori ratati, do ei mamanene dedeꞌa anik rae, hambu netatik sudi nai bee, na, hae mamataꞌu. Matak leo naak kara muste dadi rakahuluk, tehuu dae-bafok fai mateꞌen bei ta losa. <verse number="8" style="v" />Neu ko leo esa natati laban leo laen. Nusak esa natati laban nusak laen. Hambu dae nanggenggo nai bee a mesan. Ma fai ndoe-laꞌas oo, ta hohoꞌak sudi selik kana boe! Basa iar dadi reu tanda, sama leo ina kairuk fo nameda hedis sangga nae bonggi.</para>
+  <para style="p">
+    <verse number="9" style="v" />De ei muste manea matalolole! Neu ko ara mai humu rala ei fo leꞌa roo ei meni malangga anggamar uma neketu-neladi dedeꞌan miu. Ma ara popoko ei nai uma huhule-haradoik kara dale. Ma ara paꞌa reni ei, meni hatahori mana toꞌu koasa miu, nahuu ei tungga Au. Tehuu naa oo, ei hambu lelak fo dadi sakasii soa-neu Au. <verse number="10" style="v" />Manetualain hatahorin muste neu nafada nakahuluk Au Tutui Maloleng neu basa leo nai dae-bafok ia, dei fo dae-bafok fai mateꞌen losa. <verse number="11" style="v" />Masaneda, ee! Mete ma ara paꞌa reni ei meni mamana neketu-neladi dedeꞌak miu, na, ei hae mamataꞌu mae, ‘Neu ko au kokolak ae leo bee? Do, Au aselu ae leo bee?’ Mete ma faik naa losa ena, na, ei kokolak leo tungga kada hata fo Manetualain Dula-dale Malalaon nafada neu ei.<note caller="+" style="x"><char style="xo" closed="false">13:11:</char><char style="xt" closed="false">Mateos 10:17-20; Lukas 12:11-12</char></note></para>
+  <para style="p">
+    <verse number="12" style="v" />Nai uma-loo esa dale, mete ma hambu uma isi ruma ramahere neu Au, neu ko ndia toranoo bonggin sangga dalak fo ana tao nisan. Boe ma mete ma anan ndia namahere, na, ama bonggin tao nisan. Mete ma aman no inan sira ramahere neu Au, neu ko sira ana bonggin ndia tao nisa sara. <verse number="13" style="v" />De neu ko hatahorir dalen nara mburuk roo ei, nahuu ei mamahere Au. Tehuu see ndia nakatataka losa babasan, neu ko Manetualain tao nasoi-nasodan.”<note caller="+" style="x"><char style="xo" closed="false">13:13:</char><char style="xt" closed="false">Mateos 10:22</char></note></para>
+  <para style="s2">Manea besa-besa te dae-bafok fai mateꞌen sangga deka ena!</para>
+  <para style="r">(Mateos 24:15-28; Lukas 21:20-24)</para>
+  <para style="p">
+    <verse number="14" style="v" />Yesus kokolak nakandoo nae, “Hatahori esa fo manggaraun nalan seli nae mai. Ana maso neu nambariik nai mamana nelulik manai Manetualain Uma Huhule-haradoi Ina-huun, naa te ana ta nandaa neu naa, losa ana tao nunute mamanak naa. Huu naa de Manetualain nasadea ela mamanak naa. Mete ma ei mete-mita talo naa ena, na, besa-besa, ee! (See ndia lees ia, na, ana oo muste besa-besa boe). Naa dadi neu tanda nae, fai susa-sonak losa nai lelesu bafan ena. Mete ma mete-mita leo naak ena, na, hatahori manai nusa Yudea malai meni letek miu leo.<note caller="+" style="x"><char style="xo" closed="false">13:14:</char><char style="xt" closed="false">Daniel 9:27; 11:31; 12:11</char></note> <verse number="15" style="v" />Ma muste malai lai-lai, mita fo boso hambu susa-sonak. Mete ma ketuk kalua laꞌo ela uma ena, na, boso fali miu haꞌi bua-baꞌum bali. <verse number="16" style="v" />Boe ma see ndia nai osi dale, boso fali neu haꞌi lafa nelusek bali, tehuu malai makandoo leo!<note caller="+" style="x"><char style="xo" closed="false">13:16:</char><char style="xt" closed="false">Lukas 17:31</char></note> <verse number="17" style="v" />Mana kasian lenak ndia ina kairuk, ma inak kara mana rasususu ana mbimbila anan. Ara ta bisa ralai nggafak, na. <verse number="18" style="v" />Dadi malole lenak ei hule-haradoi fo moke dedeꞌa manggarauk naa, boso tuda laꞌe-ndaa fai udan. <verse number="19" style="v" />Faik naa, susa nalan seli! Mulai numa Manetualain nakadadadik dae-bafok losa hatematak ia, hatahorir bei ta mete-rita susa-sonak moꞌok matak leo naak. Ma neu ko hatahorir ta mete-rita seluk susa-sonak matak leo naak bali.<note caller="+" style="x"><char style="xo" closed="false">13:19:</char><char style="xt" closed="false">Daniel 12:1; Dae-bafo Beuk 7:14</char></note> <verse number="20" style="v" />Mete ma Manetualain ta tao kekeꞌu faik naa, neu ko ta hambu hatahori esa boe na bisa nakatataka nasoda. Manetualain tao kekeꞌu fai susa-sonak kara raa, nahuu Ana sue-lai Ndia hatahorin fo Ana here nalak ena.</para>
+  <para style="p">
+    <verse number="21" style="v" />Mete ma faik naa losa ena, ei mamanene hatahorir rae, ‘Mete dei! Karistus nai ia!’ Ma hatahori laen bali nae, ‘Karistus nai naa!’ Tehuu ei boso mamanene sara, ee! <verse number="22" style="v" />Neu ko hambu hatahori kalua fo femba tenden nae, ‘Au ia, Karistus!’ Laen bali nae, ‘Au ia, Manetualain mana toꞌu dedeꞌan.’ Neu ko ara tao tanda heran mata-matak kara pake nitu koasan fo pepeko-leleko hatahori. Ara oo soba-soba fo Manetualain hatahorin nara hambu kedi-irak boe. <verse number="23" style="v" />Tehuu Ei muste manea matalolole, ee! Fai susa-sonak kara raa ta bei losa, tehuu Au fee nesenedak memak neu ei, ee!”</para>
+  <para style="s2">Hatahori Dae-bafo Isi-isik fai mamain</para>
+  <para style="r">(Mateos 24:29-31; Lukas 21:25-28)</para>
+  <para style="p">
+    <verse number="24" style="v" />Boe ma Yesus tuti seluk bali, fo nafada ana nunin nara nae, “Mete ma fai susa-sonak kara raa basan ena,</para>
+  <para style="q1">‘Neu ko ledo dadi makiuk,</para>
+  <para style="q2">bulan oo ta nasaꞌa bali ena boe.<note caller="+" style="x"><char style="xo" closed="false">13:24:</char><char style="xt" closed="false">Yesaya 13:10; Yeskiel 32:7; Yoel 2:10, 31; 3:15; Dae-bafo Beuk 6:12</char></note></para>
+  <para style="q1">
+    <verse number="25" style="v" />Nduuk kara bese tuda ruma lalai mai,</para>
+  <para style="q2">ma basa koasa marai lalai rapiru-padok.’<note caller="+" style="x"><char style="xo" closed="false">13:25:</char><char style="xt" closed="false">Yesaya 34:4; Yoel 2:10; Dae-bafo Beuk 6:13</char></note></para>
+  <para style="p">
+    <verse number="26" style="v" />Basa naa dei fo basa hatahorir mete-rita Au, Hatahori Dae-bafo Isi-isik ia. Neu ko Au mai nai sosoꞌak numa lalai mai. Ma basa hatahorir mete-rita Au koasang, Au manula-manapung lalaꞌen!<note caller="+" style="x"><char style="xo" closed="false">13:26:</char><char style="xt" closed="false">Daniel 7:13; Dae-bafo Beuk 1:7</char></note> <verse number="27" style="v" />Boe ma Au parenda Manetualain atan nara manai nusa tetuk do inggu temak fo reu rakabubua basa hatahorir fo Au here alak kara ruma dae-bafok buꞌun haa sara mai, numa ledo toda mai losa ledo tesa; numa kii mai losa kona.”</para>
+  <para style="s1">Fai susa-sonak dadi tanda neu Lamatuak Yesus fai mamain</para>
+  <para style="r">(Mateos 24:32-35; Lukas 21:29-33)</para>
+  <para style="p">
+    <verse number="28" style="v" />Yesus tuti Ndia kokolan nae, “Au haꞌi lololek numa ai huuk mai. Mete ma doon mulai uni, naa tanda nae, fai hanas deka-deka mai ena. <verse number="29" style="v" />Leo naak oo, mete ma ei mete-mita fai susa-sonak kara mai ena, sama leo Au afada bebeik kara ia ena, naa tanda nae, Au deka-deka mai ena boe. <verse number="30" style="v" />Hatematak ia, nenene matalolole! Numa basa hatahorir mana masodak hatematak ia mai, neu ko hambu ketuk bei ta mate, tehuu fai susa-sonak kara raa mai ena. <verse number="31" style="v" />Leo mae lalai no dae-inak sambu do lalo ena, tehuu Au Dedeꞌa-kokolang ia mahanik seku neu.”</para>
+  <para style="s1">Lamatuak Yesus fai mamain naa, nemeninok</para>
+  <para style="r">(Mateos 24:36-44)</para>
+  <para style="p">
+    <verse number="32" style="v" />Yesus kokolak seluk nae, “Ta hambu hatahori esa boe na bubuluk faik bee do liꞌu hida Au fali mai. Manetualain atan nara marai nusa tetuk do inggu temak oo, ta bubuluk boe. Au mesa ngga oo ta bubuluk boe. Kada Au Amang mesa kana ndia bubuluk.<note caller="+" style="x"><char style="xo" closed="false">13:32:</char><char style="xt" closed="false">Mateos 24:36</char></note> <verse number="33" style="v" />Huu naa de ei muste manea matalolole, nahuu ei ta bubuluk neu faik bee ndia fain losa.</para>
+  <para style="p">
+    <verse number="34" style="v" />Ta dook ka ena te Au laꞌo ela ei, tehuu Au fali mai. Sama leo tenu uma laꞌo ela ndia uman fo neni mamana dook neu. Ana nadenu ndia ana mana maue-osan nara fo rafafaꞌu ralolole uma naa. Ma ana baꞌe esa-esak no uen. Ana parenda neu mana manea lelesu fo nanea no malole, losa ndia fali mai ngga.<note caller="+" style="x"><char style="xo" closed="false">13:34:</char><char style="xt" closed="false">Lukas 12:36-38</char></note> <verse number="35" style="v" />Ei oo muste manea hatu-leledon boe, nahuu ei ta bubuluk faik bee fo tenu uma fali mai ngga. Fali mai ngga nai ledo bobok do fai baꞌe duak, do leledok, do huhuak, do ledo kamatetuk. Ei ta bubuluk faik bee. <verse number="36" style="v" />Boso losak Ana mai no kaiboik boe ma ana hambu nala ei mana sunggu masanggorok kara.</para>
+  <para style="p">
+    <verse number="37" style="v" />De hata fo Au afada ei ia, Au oo afada basa hatahori laen nara ena boe ae, ‘Ei muste manea matalolole fo soru Au mamaing.’ ”</para>
+  <para style="p">[Lamatuak Yesus kola-kola no ana nunin nara numa letek Setun losa kada naa.]</para>
+  <chapter number="14" style="c" />
+  <para style="s1">Hatahori moꞌo-inahuuk kara sangga dalak fo rae humu Lamatuak Yesus no neneek</para>
+  <para style="r">(Mateos 26:1-5; Lukas 22:1-2; Yohanis 11:45-53)</para>
+  <para style="p">
+    <verse number="1-2" style="v" />Basa boe ma malangga anggama Yahudir malanggan nara bei sangga dalak fo rae humu Yesus no neneek, fo rae tao risan. Ma ara duduꞌa fo rala harak rae, “Makatataak dei! Ita boso humu Ndia lai-laik, nahuu fai maloler deka-deka ena. Boso losak hatahori noꞌuk kara ramue.”</para>
+  <para style="p">Ara kokolak talo naa, nahuu bei ela faik dua bali, hatahori Yahudir fai malolen nara fo ara raseseik rae, ‘Fai Paska’, ma ‘Fai Feta Roti Ta Pake Laru Taꞌik’. No fai maloler raa, ara rasaneda lele uluk, neu bei-baꞌin nara kalua numa nusa Masir mai.<note caller="+" style="x"><char style="xo" closed="false">14:1-2:</char><char style="xt" closed="false">Kalua numa Masir mai 12:1-27</char></note></para>
+  <para style="s1">Inak mboꞌa mina kaboo menik mabeli neu Lamatuak Yesus</para>
+  <para style="r">(Mateos 26:6-13; Yohanis 12:1-8)</para>
+  <para style="p">
+    <verse number="3" style="v" />Nai nggoro Betania, hambu hatahori esa nade Simon. Bakahulun hatahorir nunuten, nahuu ana hambu hedi kusta. Tehuu hatematak ia ana hai ena.</para>
+  <para style="p">Faik naa, fai maloler bei ta losa, Yesus asa reu raꞌa-rinu numa Simon uman. Neu ara bei raꞌa-rinu, boe ma inak esa mai natonggo no Yesus. Ana toꞌu boto esa, ara taon numa batu mai. Boto naa isin mina kaboo menik fo belin seli.<note caller="+" style="f"><char style="fr" closed="false">14:3:</char><char style="ft" closed="false">Mina kaboo menik naa belin, sama leo hatahori esa nggadin teuk esa. Susura Malalaok Dedeꞌa Yunani surak nae, mina naa belin </char><char style="it">‘denari’</char> 300, ma mina naa naden <char style="it">‘nardos’</char>, fo lele uluk hatahori taon numa ai oka kaboo menik mai. Susura Malalaok Dedeꞌa Indonesia nae ‘narwastu’. Ma boto naa, ara taon numa batu neni toꞌik mai. Boto naa oo mabeli boe. Susura Malalaok Dedeꞌa Yunani surak nae, boto naa ara taon numa batu esa nade <char style="it">‘alabastros’</char>. Susura Malalaok Dedeꞌa Indonesia nae, batu naa naden ‘batu pualam’. Mete nai Lukas 7:37-38.</note> Inak naa femba tepa boto naa leusain. Boe ma ana mboꞌa nakafafaak koe-koe mina naa neu Yesus langgan, fo dadi tanda ana fee hada-horomatak neu Yesus.</para>
+  <para style="p">
+    <verse number="4" style="v" />Tehuu hambu hatahori laen hida fo tungga raꞌa numa naa boe. Neu ara mete-rita inak naa tao talo naa, boe ma ara ramanasa, de ara rakokola koa aok rae, “Huuh! Ina hata ia, fo ana neu nggari heni hiek mina kaboo menik mabelin seli naa! <verse number="5" style="v" />Malole lenak ana seꞌo mina naa! Fo neu babaꞌe doi noꞌun nara fee hatahori mana tofa-tarak kara! Mina kaboo menik naa belin, sama leo hatahori esa nggadin teuk esa.” De ara rahara berak neun.</para>
+  <para style="p">
+    <verse number="6" style="v" />Tehuu Yesus bala nae, “Ei hae tao makasususak inak ia. Elan numa naa leo! Au amahoko, nahuu ana mboꞌa mina kaboo menik ia neu Au ao-mbaang. <verse number="7" style="v" />Hatahori mana tofa-tarak kara soa roo ei. De ei bisa tulu-fali sara sudi neu faik bee. Tehuu Au, na, ta dook ka te Au ta akabua ua ei ena.<note caller="+" style="x"><char style="xo" closed="false">14:7:</char><char style="xt" closed="false">Tui Seluk laꞌe-neu Dala Masodak 15:11</char></note> <verse number="8" style="v" />Au masodang ta dook ka ena. Ma ina mana mboꞌa mina bebeik kara ia sadia nakahuluk Au ao-mbaang, sama leo ana fee rambe memak neu Au ao-mbaang mamaten. <verse number="9" style="v" />Masaneda matalolole, ee! Nai bee a mesan, Manetualain Tutui Malolen natanggela nai dae-bafok ia, neu ko ara oo tui inak ia malolen boe, mita fo basa hatahorir rasanedan.”</para>
+  <para style="s1">Yudas nala harak fo nae seꞌo Lamatuak Yesus</para>
+  <para style="r">(Mateos 26:14-16; Lukas 22:3-6)</para>
+  <para style="p">
+    <verse number="10" style="v" />Basa boe ma Yesus ana nuni kasalahunu duan nara, esa nade Yudas Iskariot. Ana kalua neu sangga malangga anggama Yahudir malanggan nara fo nae seꞌo heni Yesus neu sara. Ana losa neu sara, boe ma nafada ndia dale ikon. <verse number="11" style="v" />Malangga anggamar ramanene Yudas nae talo naa, boe ma ara ramahoko ralan seli. De ara helun rae, “Mete ma o nau seꞌo Yesus neu ai, na, ai bae.” Boe ma Yudas kalua dea neu, de ana sangga dalak fo nae fee Yesus neu sara.</para>
+  <para style="s1">Lamatuak Yesus naꞌa feta Paska no ana nunin nara</para>
+  <para style="r">(Mateos 26:17-25; Lukas 22:7-14, 21-23; Yohanis 13:21-30)</para>
+  <para style="p">
+    <verse number="12" style="v" />Basa boe ma Yesus ana nunin nara mai ratanen rae, “Papa! Faik ia ita Fai Paska ena. De Papa nau ai miu sadia mamana feta Paska nai bee?” Te faik naa hatahori Yahudir fai malole makasososan. Nai faik naa ara rasiꞌe tunu roti ta pake laru taꞌik, ma ara oo hala bibi lombo boe.</para>
+  <para style="p">
+    <verse number="13" style="v" />Boe ma Yesus nadenu ana nunin dua nae, “Ei dua ngga makahuluk meni kota miu. Nai naa ei matonggo mia touk esa nasaa oe nai nggusi anak esa dale. Ei miu laꞌo tunggan leo. <verse number="14" style="v" />Mete ma ana maso neni uma bee neu, na, ei tungga naa miu. Basa naa, ei mafada tenu uma naa mae, ‘Papa! Ai Papa Mesen noke mamanak esa, fo nae paken neu mamana feta Paska no ana nunin nara.’ <verse number="15" style="v" />Neu ko tenu uma naa dudu fee ei kama loak esa nai uma tadak lain. Ana sadia nala kama naa no matetuk ena. Ela kada ei dua ngga miu sadia nanaꞌak nai naa leo.”</para>
+  <para style="p">
+    <verse number="16" style="v" />De dua sara laꞌo reni kota reu. Numa naa ara ratonggo ro basa hata fo Yesus nafada memak neu sara naa ena. Boe ma ara sadia basa-basan fo Yesus asa raꞌa feta Paska nai naa. Basa boe ma dua sara reu roke Yesus asa.</para>
+  <para style="p">
+    <verse number="17" style="v" />Neu ledo mulai tesa ena, boe ma Yesus no ana nuni kasalahunu duan nara reni naa reu. <verse number="18" style="v" />Boe ma basa sara ranggatuuk, de raꞌa-rinu sama-sama. Neu ara raꞌa-rinu, boe ma Yesus kokolak nae, “Ei nenene ee! Hambu hatahori esa numa ei taladam mara mai, neu ko ana seꞌo heni Au neni hatahori laen nara neu.”<note caller="+" style="x"><char style="xo" closed="false">14:18:</char><char style="xt" closed="false">Sosoda Kokoa-kikiok kara 41:10</char></note></para>
+  <para style="p">
+    <verse number="19" style="v" />Ara ramanene rala naa, boe ma dalen nara rameda ta malole. De ara esa-esak ratane Yesus rae, “Hatahori fo Papa nafadak naa, ta ndia au, hetu?”</para>
+  <para style="p">
+    <verse number="20" style="v" />Yesus naselu nae, “Hatahori fo mana sama-sama no Au boro roti neni manggo ia dale neu naa ndia neu ko nae seꞌo heni Au. <verse number="21" style="v" />Masaneda, ee! Au, Hatahori Dae-bafo Isi-isik ia muste mate sama leo neni surak memak nai Manetualain Susura Malalaon dale. Tehuu besa-besa! Hatahori fo mana nae seꞌo heni Au naa, ana ndia lemba-nasaa nala ndia sosoen. Malolen lenak mete ma inan ta bonggi sana!”</para>
+  <para style="s2">Lamatuak Yesus nafada nae, roti no oe anggor naa dadi neu tanda fo ita tasaneda neu Ndia</para>
+  <para style="r">(Mateos 26:26-30; Lukas 22:14-20; 1 Korentus 11:23-25)</para>
+  <para style="p">
+    <verse number="22" style="v" />Neu ara bei raꞌa, boe ma Yesus soꞌu botik roti balok esa, fo noke makasi neu Manetualain. Boe ma Ana fifiꞌi baꞌe roti naa, de Ana loon neu ana nunin nara, ma nafada nae, “Roti ia, Au ao-mbaang. Haꞌi malan fo miꞌa leo!”</para>
+  <para style="p">
+    <verse number="23" style="v" />Basa naa, Ana haꞌi nala nggalaas neni isi oe anggor. Ana oo noke makasi neu Manetualain boe. Basa boe ma Ana loo nggalaas naa neu ana nunin nara fo basa sara rinu. <verse number="24" style="v" />Boe ma Ana nae, “Anggor ia, Au daang. Neu ko titi henin fo tao nasoi-nasoda hatahori noꞌuk ka. Daak ia, dadi bukti fo tasaneda tae, hata fo Manetualain helu-bartaak ena, memak hatematak ia ana dadi ena. Haꞌi malan fo minu leo.<note caller="+" style="x"><char style="xo" closed="false">14:24:</char><char style="xt" closed="false">Kalua numa Masir mai 24:8; Yermia 31:31-34</char></note></para>
+  <para style="p">
+    <verse number="25" style="v" />Nenene matalolole dei! Mulai numa leꞌodaen ia neu, Au ta inu oe anggor ena. Losa Au anggatuuk parenda sama-sama ua Au Amang manai nusa tetuk do inggu temak, dei fo Au inu bali.”</para>
+  <para style="p">
+    <verse number="26" style="v" />Basa boe ma ara soda sosodak esa fo koa-kio neu Manetualain. Boe ma ara kalua leꞌodaek naa fo reni letek Setun reu.</para>
+  <para style="s1">Lamatuak Yesus nafada nakahuluk nae, neu ko Petrus laka nae, ta nalela Ndia</para>
+  <para style="r">(Mateos 26:31-35; Lukas 22:31-34; Yohanis 13:36-38)</para>
+  <para style="p">
+    <verse number="27" style="v" />Neu ara bei laꞌok naa, Yesus nafada memak nae, “Neu ko leꞌodaen ia, ei basa ngga malai laꞌo ela Au. Naa sama leo ara surak memak nai Manetualain Susura Malalaon dale nae,</para>
+  <para style="q1">‘Neu ko Manetualain tao nisa mana lolo,</para>
+  <para style="q2">de bibi lombon nara ralai sasarak.’<note caller="+" style="x"><char style="xo" closed="false">14:27:</char><char style="xt" closed="false">Sakaria 13:7</char></note></para>
+  <para style="p">
+    <verse number="28" style="v" />Memak Au mate. Ma neu ko mete ma Au asoda fali numa mamates mai ena, na, Au laꞌo akahuluk ei uni profensi Galilea uu.”<note caller="+" style="x"><char style="xo" closed="false">14:28:</char><char style="xt" closed="false">Mateos 28:16</char></note></para>
+  <para style="p">
+    <verse number="29" style="v" />Boe ma Petrus nasabara nae, “Papa! Leo mae basa hatahori laen nara ralai laꞌo ela Papa oo, au ta alai boe!”</para>
+  <para style="p">
+    <verse number="30" style="v" />Yesus naselu nae, “Peꞌu! Masaneda, ee! Leꞌodaen ia, manu bei ta kokoa laꞌe dua, tehuu o kokolak laꞌe telu ena mae, o ta malela Au!”</para>
+  <para style="p">
+    <verse number="31" style="v" />Tehuu Petrus naselu nahere nae, “Taa, Papa! Mete ma Papa mate, na, au oo mate sama-sama ua Papa boe. Au ta alai laꞌo ela Papa, ma au ta laka ae, ta alela Papa!”</para>
+  <para style="p">Petrus nonoon laen nara oo, esa-esak nae leo naa boe.</para>
+  <para style="s1">Lamatuak Yesus hule-haradoi numa osi Getsemani</para>
+  <para style="r">(Mateos 26:36-46; Lukas 22:39-46)</para>
+  <para style="p">
+    <verse number="32" style="v" />Basa naa, Yesus asa laꞌok rakandoo losa osi esa nai letek Setun nade ‘Getsemani’. Boe ma Yesus nafada sara nae, “Ei manggatuuk mahani ia, ee. Au nau uu hule-haradoi nai naa.”</para>
+  <para style="p">
+    <verse number="33" style="v" />Tehuu Yesus noke no Petrus, Yakobis ma Yohanis fo ara laꞌok ro Ndia. Mulai numa naa neu, Yesus dalen sona ma ta natetu faa boe na. <verse number="34" style="v" />Yesus nafada sara nae, “Au daleng susa nalan seli! Au ameda nok bali ae mate a ena. Ei manggatuuk manea mai ia dei.”</para>
+  <para style="p">
+    <verse number="35-36" style="v" />Boe ma Yesus laꞌo nakadodook aon faa, de Ana sendek luu-langgan neu daer fo Ana hule-haradoi nae, “Papa. Mete ma Papa nau, na, Au hae lemba-asaa doidosok naa losa mate leo iak. Au bubuluk memak ena ae, ta hambu hata esa boe na fo Papa ta bisa tao nalan. De mete ma Papa nau, na, nggari makadodook doidosok ia numa Au mai. Tehuu boso tungga Au hihii-nanaung, naa fo tungga kada Papa hihii-nanaun.”</para>
+  <para style="p">
+    <verse number="37" style="v" />Basa boe ma Ana fali neni ana nuni katelun nara neu, tehuu ara sunggu seli. Boe ma Yesus fafae sara, de kokolak no Petrus nae, “Heeh, Peꞌu!<note caller="+" style="f"><char style="fr" closed="false">14:37:</char><char style="ft" closed="false">Susura Malalaok dedeꞌa Yunani surak nai ia nae, ‘Simon’. Simon naa, Petrus naden laen.</char></note> O sunggu, do? Au numa naa ta doo anak ka, tehuu ei ta bisa beꞌe manea faa boe na. <verse number="38" style="v" />Kukuku maneu o matam dei. Boe ma mambadeik fo manea mua Au. Ei dalem mara memak nau tao neulauk, tehuu ei ao-inam barakai taak. De malole lenak ei hule-haradoi fo mete ma hambu soba-douk, na, ta senggi ei.”<note caller="+" style="x"><char style="xo" closed="false">14:38</char><char style="xt" closed="false">1 Korentus 10:13</char></note></para>
+  <para style="p">
+    <verse number="39" style="v" />Basa boe ma Yesus neu hule-haradoi seluk laꞌe esa bali. Ana hule seluk neu Manetualain fo boso fee Ndia lemba-nasaa doidosok naa. <verse number="40" style="v" />Boe ma Ana fali neni ana nuni katelun nara neu. Tehuu ara sunggu seluk bali, nahuu matan nara ramabera ralan seli. Boe ma Ana fafae seluk kasa bali, tehuu ara ta bubuluk fo raselu rae leo bee neu Yesus.</para>
+  <para style="p">
+    <verse number="41" style="v" />Basa boe ma Yesus laꞌo ela sara bali fo neu hule-haradoi seluk laꞌe katelun. Boe ma Yesus fali, de Ana fafae sara. Ana nae, “Ei bei sunggu bali, do? Dai ena! Mambadeik! Hatahori fo nae seꞌo heni Au, Hatahori Dae-bafo Isi-isik ia, deka ena. Hatematak ia ara rae humu Au, fo ara fee Au uni hatahori manggarauk kara liman uu. <verse number="42" style="v" />Mambadeik leo! Buka ei matam mara fo mete sudi neni naa neu dei! Hatahori fo nae seꞌo heni Au naa, ana mai ena. Mai fo ita teu tatonggo too sara!”</para>
+  <para style="s1">Humu rala Lamatuak Yesus</para>
+  <para style="r">(Mateos 26:47-56; Lukas 22:47-53; Yohanis 18:3-12)</para>
+  <para style="p">
+    <verse number="43" style="v" />Neu Yesus bei kola-kola talo naa, te nggengger neuk ka, Yudas mai ena no hatahori noꞌun seli. Ara mai reni tafa mukuk ma tongga fo rae humu Yesus. Ara tao talo naa, tungga parenda numa malangga Yahudir malanggan nara mai. Sira raa, ndia malangga anggama malanggan nara, meser anggamar, ma lasi-lasi hadak kara. <verse number="44" style="v" />Yudas fee tanda memak kasa ena nae, “Ei mete matalolole, ee! Au idu see, na, ei humu malan leo! Ndia naa, ndia hatahori fo ei sanggak!”</para>
+  <para style="p">
+    <verse number="45" style="v" />Dadi, neu Yudas asa losa naa, boe ma Yudas nasare matan no Yesus. De ana nahara nae, “Papa Meser!” Boe ma ana holu ma idu Yesus. <verse number="46" style="v" />Basa boe ma hatahori noꞌuk kara mata reu fo humu Yesus.</para>
+  <para style="p">
+    <verse number="47" style="v" />Tehuu Yesus hatahorin esa lesu nala fela mukun, de ana sambi naketu hatahori esa ndiꞌi doon. Hatahori mana makahinak naa, ndia malangga anggama Yahudi malangga ina-huun hatahori neondan. <verse number="48" style="v" />Boe ma Yesus kokolak no hatahorir fo mana mai humu Ndia naa nae, “Talo bee? Ei duꞌa mae, Au ia hatahori manggarauk, do? De ei mai humu Au meni tafa ma tongga? <verse number="49" style="v" />Tungga faik Au anori ei nai Manetualain Uma Huhule-haradoik Ina-huun dale, ma ta hambu esa boe na mai humu Au. Mai, humu mala Au leo! Te ia neni surak memak kana numa lele uluk mai nai Manetualain Susura Malalaon dale ena.”<note caller="+" style="x"><char style="xo" closed="false">14:49:</char><char style="xt" closed="false">Lukas 19:47; 21:37</char></note></para>
+  <para style="p">
+    <verse number="50" style="v" />Yesus ana nunin nara ramataꞌu ralan seli. Boe ma ara ralai laꞌo ela kada Yesus mesa kana.</para>
+  <para style="p">
+    <verse number="51" style="v" />Numa naa oo, hambu tou muri anak esa tungga Yesus dean boe. Ana naluse ao-inan nenik kada sidi anak esa. Hatahorir raa rae humun boe. <verse number="52" style="v" />Tehuu ara ndaso rala kada sidin, de mboꞌi henin. Boe ma ana nalai fali neu ngga no kada makaholak, nahuu namataꞌu nalan seli ena.</para>
+  <para style="s1">Ara roo Lamatuak Yesus neni mamana neketu-neladi dedeꞌa anggama neu</para>
+  <para style="r">(Mateos 26:57-68; Lukas 22:54-55, 63-71; Yohanis 18:13-14, 19-24)</para>
+  <para style="p">
+    <verse number="53" style="v" />Basa boe ma ara toꞌu roo Yesus neni anggama Yahudi malangga ina-huun uman neu. Numa naa, hatahori moꞌo-inahuuk kara rakabua ena. Sira ndia malangga anggamar malanggan nara, meser anggamar, ma lasi-lasi hadak kara.</para>
+  <para style="p">
+    <verse number="54" style="v" />Neu ara humu reni Yesus, Petrus laꞌo bambi-bambi tungga dea losa nai anggama Yahudi malangga ina-huun uman. Ana oo maso neni uma bebelan neu, de nanggatuuk dara aꞌi sama-sama no hatahori manear marai naa.</para>
+  <para style="p">
+    <verse number="55" style="v" />Numa uma naa dale, malangga anggamar malanggan nara kola-kola ro hatahorir mana maketu-maladi dedeꞌa nai mamana neketu-neladi dedeꞌa anggama. Basa sara sangga bukti fo nau fee salak neu Yesus nahuu ara rae hukun mates neun. Tehuu ara ta hambu bukti hata esa boe na. <verse number="56" style="v" />Boe ma ara roke sakasii noꞌuk ka fo sangga rakatutudak Yesus. Tehuu kokolan nara esa ta nandaa no esa.</para>
+  <para style="p">
+    <verse number="57" style="v" />Boe ma hambu sakasii hida bali rambariik fo kokolak pepeko-lelekok rae, <verse number="58" style="v" />“Ai mamanene hatahori ia kokolak nae, ‘Neu ko Au ndefa heni Uma Huhule-haradoi Ina-huuk fo hatahori dae-bafok rambadedeik kana no liman nara. Basa faik telu bali, na, neu ko Au ambaririik falik Uma naa, tehuu ta pake hatahori dae-bafok liman.’ ”<note caller="+" style="x"><char style="xo" closed="false">14:58:</char><char style="xt" closed="false">Yohanis 2:19</char></note> <verse number="59" style="v" />Tehuu sira kokolan naa, esa ta nandaa no esa.</para>
+  <para style="p">
+    <verse number="60" style="v" />Basa boe ma malangga ina-huuk naa, nambariik neu basa hatahori mana maketu-maladi dedeꞌa matan nai mamana neketu-neladi dedeꞌa anggama naa. Boe ma ana natane Yesus nae, “Hatahori noꞌuk ka kalaak O. Tao hata de O ta mahara?”</para>
+  <para style="p">
+    <verse number="61" style="v" />Tehuu Yesus ta nahara faa boe na. Basa boe ma malangga ina-huuk naa natane seluk kana bali nae, “Hena O mafada dei! Memak O ia tebe-tebe ndia Karistus, Manetualain Anan fo Ana helu-bartaan numa lele uluk mai naa ena, do?”</para>
+  <para style="p">
+    <verse number="62" style="v" />Yesus naselu nae, “Memak tebe! Karistus naa, ndia Au ia. Neu ko ei basa ngga mete-mita Au, Hatahori Dae-bafo Isi-isik ia anggatuuk nai nusa tetuk do inggu temak nai Manetualain boboa konan. Ndia koasan ta neni babanggak! Neu ko Au ua Ndia toꞌu parenda sama-sama! Basa naa, neu ko Au konda numa nusa tetuk do inggu temak mai ua sosoꞌak.”<note caller="+" style="x"><char style="xo" closed="false">14:62:</char><char style="xt" closed="false">Daniel 7:13</char></note></para>
+  <para style="p">
+    <verse number="63" style="v" />Malangga ina-huuk naa namanene Yesus kokolak talo naa, boe ma ana namanasa nalan seli, losa ana sii nasida badu narun. Boe ma ana bolu nafada neu basa hatahori mana nggero-furak kara nai mamana neketu-neladi dedeꞌa anggama naa nae, “Ita ta parluu sakasii ena! <verse number="64" style="v" />Ei mamanene no ei ndiꞌi doo heli-helim mara ena, Ndia mesa kana kokolak talo naa, hetu? Ana soꞌuk aon dadi neu Manetualain Anan. Ia nakadadaek nalan seli Manetualain ia! Tungga anggama hohoro-lalanen, mete ma hambu hatahori esa soꞌuk aon sama leo Manetualain, na, hatahori naa muste tao maten! De hatematak ia, ei nau maketu-maladi taon talo bee?”</para>
+  <para style="p">Boe ma basa sara raketu rae, “Hatahori ia memak tebe-tebe sala! Dadi Ana muste hambu hukun mates!”<note caller="+" style="x"><char style="xo" closed="false">14:64:</char><char style="xt" closed="false">Malangga Anggamar Hohoro-lalanen 24:16</char></note></para>
+  <para style="p">
+    <verse number="65" style="v" />Boe ma hatahori hida mata reu, de ara pura ambe neu Yesus. Ara mboti ketu matan, boe ma ara popokon. Basa boe ma ara radenun rae, “Mete ma O Manetualain mana toꞌu dedeꞌan, na, selu sudik see ndia tutu O?” Basa boe ma ara fee parenda neu hatahorir mana manea Uma Huhule-haradoi Ina-huuk fo mai reni Yesus. Ara roon neu, boe ma ara famba rakamiminak kana.</para>
+  <para style="s1">Petrus kokolak laꞌe telu nae, ndia ta nalela Lamatuak Yesus</para>
+  <para style="r">(Mateos 26:69-75; Lukas 22:56-62; Yohanis 18:15-18, 25-27)</para>
+  <para style="p">
+    <verse number="66-67" style="v" />Faik naa, Petrus bei nanggatuuk sama-sama numa uma bebelan. Boe ma anggama Yahudi malangga ina-huun ata inan esa mai meten dara aꞌi. Ana namumula Petrus matan, boe ma ana kokolak nae, “Bebeik kara ia o tungga sama-sama mua Yesus, hatahori Nasaret naa boe, hetu? Tebe, hetu?”</para>
+  <para style="p">
+    <verse number="68" style="v" />Tehuu Petrus naselu nae, “Taa! Tao hata de o matane talo naa! Au ta alela sana.” Boe ma Petrus kalua fo neu nambariik neu mbaꞌa lelesu matan. [Hatematak naa oo manu kokoa boe.]<note caller="+" style="f"><char style="fr" closed="false">14:68:</char><char style="ft" closed="false">Susura dedeꞌa Yunani ketuk ta surak dedeꞌa deꞌek kara nai kurun dale ia</char></note></para>
+  <para style="p">
+    <verse number="69" style="v" />Boe ma ata inak naa mete-nita seluk Petrus bali. De nafada basa hatahorir marai naar nae, “Ndia ia, esa numa hatahorir raa mai!”</para>
+  <para style="p">
+    <verse number="70" style="v" />Boe ma Petrus nasabara nae, “Fama te, o kamuluk! Au ta alela Hatahori naa, ma!”</para>
+  <para style="p">Doo-doo faa boe ma hatahori laen esa numa naa kokolak seluk bali neu Petrus nae, “Wee! O bei nau masapepeko bali mae, o ta sama-sama mua hatahorir raa! Heeh! Ei basa ngga, hatahori Galilea, hetu?”</para>
+  <para style="p">
+    <verse number="71" style="v" />Tehuu Petrus nareresi bali nae, “Heeh! Au sumba-soo! Au ta alela Hatahori naa!”</para>
+  <para style="p">
+    <verse number="72" style="v" />Ndaa no ana kokolak talo naa, boe ma manu kokoa laꞌe kaduan. Boe ma Petrus nasaneda Yesus kokolan bebeik kara nae, “Manu bei ta kokoa laꞌe dua, tehuu o laka laꞌe telu ena mae, o ta malela Au.”</para>
+  <para style="p">Petrus nasaneda Yesus kokolan naa, boe ma ana buꞌi nakarereu.</para>
+  <chapter number="15" style="c" />
+  <para style="s1">Ara leꞌa roo Lamatuak Yesus neu nasare nggubenor Pilatus</para>
+  <para style="r">(Mateos 27:1-2, 11-14; Lukas 23:1-5; Yohanis 18:28-38)</para>
+  <para style="p">
+    <verse number="1" style="v" />Bei huhua anan seli, basa hatahorir marai mamana neketu-neladi dedeꞌak naa, rala harak fo rae tao risa Yesus. De ara futu-paꞌa roon neu nasare nggubenor Pilatus. <verse number="2" style="v" />Neu ara losa nggubenor Pilatus, boe ma ana natane Yesus nae, “Talo bee? Tebe-tebe O ia, hatahori Yahudir Manen, do?”</para>
+  <para style="p">Yesus naselu nae, “Tebe. Papa nggubenor kokolak ndaa naa ena.”</para>
+  <para style="p">
+    <verse number="3" style="v" />Boe ma malangga anggamar malanggan nara kokolak ro nggubenor rae, “Hatahori ia tao salak noꞌun seli ena!” De ara hingga salan esa-esak.</para>
+  <para style="p">
+    <verse number="4" style="v" />Boe ma nggubenor natane seluk Yesus bali nae, “O ta mamanene sira kokolan nara de? Ara fee salak noꞌun seli neu O ena. Soba O bala dei!”</para>
+  <para style="p">
+    <verse number="5" style="v" />Tehuu Yesus ta naselu hata esa boe na, losa nggubenor heran bali-bali.</para>
+  <para style="s2">Nggubenor Pilatus naketu hukun mates neu Lamatuak Yesus</para>
+  <para style="r">(Mateos 27:15-26; Lukas 23:13-25; Yohanis 18:39—19:16)</para>
+  <para style="p">
+    <verse number="6" style="v" />Tungga teuk, mete ma hatahori Yahudir tao feta Paska, hatahori noꞌuk kara rasiꞌe here rala hatahori bui esa fo nggubenor nakamboꞌik kana. <verse number="7" style="v" />Faik naa hatahori bui esa, nade Barabas. Fai maneuk kara ara humu ralan no nonoon nara, nahuu ana laban man-parenda Roma, ma ana oo nakanisa hatahori boe. <verse number="8" style="v" />Huu feta Paska sangga deka ena, de hatahori noꞌuk ka reni nggubenor Pilatus reu, de ara eki rae, “Papa nggubenor! Fai Paska mai ena. Mete ma bisa, na, Papa nggubenor tulun fo makamboꞌik hatahori bui esa tungga ai siꞌen!”</para>
+  <para style="p">
+    <verse number="9" style="v" />Boe ma nggubenor naselu nae, “Au ae akamboꞌik see? Talo bee, leo au akamboꞌik ei hatahori Yahudi Manen ia? Ei makaheik, do?” <verse number="10" style="v" />Nggubenor kokolak talo naa, naa te ana bubuluk ena malangga anggamar malanggan nara leꞌa roo Yesus neni ndia neu, nahuu ara mburuk ralan seli neu Yesus.</para>
+  <para style="p">
+    <verse number="11" style="v" />Tehuu malangga anggamar malanggan nara dudunggu hatahori noꞌuk kara raa, de basa sara roke nggubenor rae, “Ai ta nau sana! Makamboꞌik kada Barabas dei!”</para>
+  <para style="p">
+    <verse number="12" style="v" />Boe ma nggubenor natane seluk nae, “Mete ma talo naa, na, Au tao Yesus talo bee, fo roken rae, ‘Mane hatahori Yahudi’ ia?”</para>
+  <para style="p">
+    <verse number="13" style="v" />Boe ma basa sara eki rame-rame rae, “Tao misa kada Yesus! Pakun neu ai ngganggek!”</para>
+  <para style="p">
+    <verse number="14" style="v" />Boe ma nggubenor natane nae, “Ana sala hata? Au parisan ena, te au ta hambu Ana sala hata esa boe na!”</para>
+  <para style="p">Tehuu basa sara boe eki rahere bali rae, “Tao misan! Pakun neu ai ngganggek leo!”</para>
+  <para style="p">
+    <verse number="15" style="v" />Huu nggubenor sangga tao namahoko hatahori noꞌuk kara dalen nara, de ana mboꞌi Barabas, tungga sira hihiin. Boe ma ana parenda mana manear fo reu poko-femba Yesus pake fifiuk.<note caller="+" style="f"><char style="fr" closed="false">15:15:</char><char style="ft" closed="false">Soldadu Romar pake fifiuk fo neni iꞌik numa tali banda rouk, taruk hida. Boe ma ara paꞌa dui tandek, do engge tandek neu tali suꞌun nara. Mete ma poko-femba laꞌi-laꞌik kana pake fifiuk naa, lofa heni rouk kara.</char></note> Ara poko-femba basan, boe ma soldadur leꞌa renin leo fo rae reu paku tao risan neu ai ngganggek.</para>
+  <para style="s1">Soldadur poko-femba rakamiminak Lamatuak Yesus</para>
+  <para style="r">(Mateos 27:27-31; Yohanis 19:2-3)</para>
+  <para style="p">
+    <verse number="16" style="v" />Basa boe ma soldadur leꞌa roo Yesus neni sira uma bebela loan neu.<note caller="+" style="f"><char style="fr" closed="false">15:16:</char><char style="ft" closed="false">Soldadu mamanan naa roke tungga dedeꞌa Latin rae, </char><char style="it">praetorium</char>. Soldadur raa mamana heli-helin nara rai uma dines eko-feon.</note> Numa mamanak naa, roke rala sira nonoon nara batalion esa. <verse number="17" style="v" />De ara fee Yesus pake badu naru mbila maranggeok esa, sama leo manek kara bualoꞌa-papaken nara. Boe ma ara haꞌi ai dila-nggauk longgen, de ara nanen dadi neu solangga. Boe ma ara ndeꞌi solangga kanggouk naa neu Yesus langgan, fo rakamiminak kana sama leo rae soꞌu mane beuk fo feen pake solangga manek.</para>
+  <para style="p">
+    <verse number="18" style="v" />Boe ma basa sara fee hada-horomatak rakamiminak kana, ma rae, “Sodak Papa Manek Yahudi!” <verse number="19" style="v" />Boe ma ara kaur rakekeik langgan nara mbali Yesus. Basa boe ma ara pupura ambe neu matan, ma ara dedelu laꞌi-laꞌik ka neun pake ai. <verse number="20" style="v" />Ara rakamiminak basan, boe ma ara buka heni badu naruk naa. De ara feen pake falik bua-loꞌan nara. Basa boe ma ara roon laꞌo ela kota Yerusalem fo reu paku londan neu ai ngganggek lain losa maten.</para>
+  <para style="s1">Ara paku Lamatuak Yesus nai ai ngganggek lain</para>
+  <para style="r">(Mateos 27:32-44; Lukas 23:26-43; Yohanis 19:17-27)</para>
+  <para style="p">
+    <verse number="21" style="v" />Neu ara bei laꞌok kalua numa Yerusalem mai, boe ma ara ratonggo ro hatahori esa numa kota Kirene mai. Hatahori naa, nade Simon. Ndia ia, Aleksander ma Rufus aman. Ana dei fo nae maso neni Yerusalem neu, tehuu soldadur toꞌu ralan, de rakasetik kana lemba-nasaa nala Yesus ai ngganggen.<note caller="+" style="x"><char style="xo" closed="false">15:21:</char><char style="xt" closed="false">Roma 16:13</char></note> <verse number="22" style="v" />Ara leꞌa roo Yesus neni mamanak esa neu nade Golgotaa. (Ndia sosoa-ndandaan nae, ‘mamana langga duik’.) <verse number="23" style="v" />Numa naa, ara fee Yesus ninu anggor makeis neni seseok no modo-aidoo, mita fo Ana bisa nakataka hedis. Tehuu Yesus ta nau ninu. <verse number="24-25" style="v" />Basa boe ma ara paku ralelengga Yesus neu ai ngganggek lain. De ara rambaririik ai ngganggek naa, fama te neu liꞌu sio huhuan. Boe ma soldadu leꞌa lot fo sangga bubuluk see ndia hambu Yesus bua-loꞌan nara.<note caller="+" style="x"><char style="xo" closed="false">15:24-25:</char><char style="xt" closed="false">Sosoda Kokoa-kikiok kara 22:19</char></note> <verse number="26" style="v" />Basa boe ma ara surak neu papak esa, de ara pakun neu Yesus langgan dandaan lain nae,</para>
+  <para style="qc">
+    <char style="it">“Ia, hatahori Yahudir Manen.”</char></para>
+  <para style="p">Ara pake naa dadi neu huun fo hukun Yesus. <verse number="27" style="v" />Numa naa oo, ara paku tao risa hatahori naꞌo manu-meo dua boe. Esa nai Yesus boboa konan, ma esa nai boboa kiin. <verse number="28" style="v" />[No dalak naa, ara tungga hata fo neni surak memak nai Manetualain Susuran nae, “Ara taon sama leo hatahori manggarauk.”]<note caller="+" style="f"><char style="fr" closed="false">15:28:</char><char style="ft" closed="false">Susura dedeꞌa Yunani lasin lenak kara, ta surak lanek ka-28 ia.</char></note> <note caller="+" style="x"><char style="xo" closed="false">15:28:</char><char style="xt" closed="false">Yesaya 53:12</char></note></para>
+  <para style="p">
+    <verse number="29" style="v" />Basa hatahorir fo mana laꞌo tungga naa, mete-rita Yesus neni londak nai ai ngganggek lain. Boe ma ara kakale langgan nara ma rakatitiik-rakamamaek Yesus rae, “Weeh! O mae O bisa tao mandefa heni Manetualain Uma Huhule-haradoi Ina-huun fo mambadedeik falik kana doon kada faik telu, hetu?<note caller="+" style="x"><char style="xo" closed="false">15:29:</char><char style="xt" closed="false">Sosoda Kokoa-kikiok kara 22:8; 109:25; Markus 14:58; Yohanis 2:19</char></note> <verse number="30" style="v" />Soba O konda numa ai ngganggek naa lain mai, fo makamboꞌik O aom leo! Mete ma dadi talo naa, na, dei fo ai mamahere memak mae, O ia Manetualain Anan.”</para>
+  <para style="p">
+    <verse number="31" style="v" />Malangga anggama Yahudir malanggan nara ma meser anggamar oo rakatitiik Yesus boe, ma ara kokolak rae, “Ana tao nasoi-nasoda hatahori laen, tehuu ana ta bisa tao nasoi-nasoda Ndia ao heli-helin! <verse number="32" style="v" />Ana nae, Ndia naa, ‘Karistus’, fo Manetualain helu-bartaa memak kana numa lele uluk mai. Hatahori laen rae, Ndia ia hatahori Israel Manen. Mete ma tebe leo naak, na, elan numa naa fo Ana konda numa ai ngganggek lain mai, fo ita mete-tita dei. Mete ma tebe leo naak, dei fo ita bisa tamahere neun.”</para>
+  <para style="p">Hatahori kaduak kara raa fo neni londak sama-sama ro Yesus numa ai ngganggek naa oo tungga rakatitiik Yesus boe.</para>
+  <para style="s1">Lamatuak Yesus mate</para>
+  <para style="r">(Mateos 27:45-56; Lukas 23:44-49; Yohanis 19:28-30)</para>
+  <para style="p">
+    <verse number="33" style="v" />Basa naa, makiu makahatuk tatana nala mamanak naa numa ledo namatetu losa liꞌu telu ledo bobon. <verse number="34" style="v" />Ndaa no liꞌu telu ledo bobon, boe ma Yesus eki pake dedeꞌa Aram nae, <char style="it">“Eloi! Eloi! Lema sabaktani?”</char> (Sosoa-ndandaan nae, “Au Lamatuang! Au Manetualaing, ee! Tao hata de Amak masadea laꞌo ela Au talo ia?”)<note caller="+" style="x"><char style="xo" closed="false">15:34:</char><char style="xt" closed="false">Sosoda Kokoa-kikiok kara 22:2</char></note></para>
+  <para style="p">
+    <verse number="35" style="v" />Hambu hatahori hida deka-deka ruma naa, ramanene Yesus haran naa. Boe ma rae, “Hoi! Ei mamanene dei. Ana nanggou Elia, Manetualain mana toꞌu dedeꞌan lele uluk naa!” <verse number="36" style="v" />Boe ma hatahori esa nalaik neu haꞌi lombu, de ana boron neni anggor makeis dale neu. Boe ma ana nato lombu naa neu teteꞌe ai suꞌun, de soron neni Yesus bifi doon neu, fo Ana musi. Boe ma hatahori naa kokolak nae, “Tahani fo ita mete sudik kana. Fama te Elia mai fo nakondan numa ai ngganggek lain mai.”<note caller="+" style="x"><char style="xo" closed="false">15:36:</char><char style="xt" closed="false">Sosoda Kokoa-kikiok kara 69:22</char></note></para>
+  <para style="p">
+    <verse number="37" style="v" />De Yesus eki seluk bali, boe ma maten.</para>
+  <para style="p">
+    <verse number="38" style="v" />Nai Uma Huhule-haradoi Ina-huuk dale, hambu tema loak esa neni londak fo babata neu Manetualain Kama Malalaon Mateꞌen. Ndaa no Yesus ketu ani hahaen, boe ma temak naa sii baꞌen neu dua, numa lain mai losa dae.<note caller="+" style="x"><char style="xo" closed="false">15:38:</char><char style="xt" closed="false">Kalua numa Masir mai 26:31-33</char></note></para>
+  <para style="p">
+    <verse number="39" style="v" />Numa Golgotaa, hambu komedan mana manea esa, nambariik deka no Yesus ai ngganggen. Neu ana mete-nita Yesus mamaten, ana nggengger. Boe ma ana nae, “Awii! Hatahori ia, memak tebe-tebe Manetualain Anan, ee!”</para>
+  <para style="p">
+    <verse number="40-41" style="v" />Ma hambu inak hida fo ara tungga mete Yesus mamaten numa dook ka mai. Inak kara raa, ndia bakahulun raono-lalau Yesus asa numa Galilea. Sira raa, ndia Salomi, Maria numa nusak Magdala mai ma Maria esa bali (fo Yakobis anak no Yoses<note caller="+" style="f"><char style="fr" closed="false">15:40-41:</char><char style="ft" closed="false">Hambu susura dedeꞌa Yunani ketuk rae ‘Yoses inan’, ma ketuk rae ‘Yosef inan’.</char></note> inan), ma inak laen noꞌuk ka bali mana sama-sama ro Yesus reni Yerusalem mai.<note caller="+" style="x"><char style="xo" closed="false">15:40-41:</char><char style="xt" closed="false">Lukas 8:2-3</char></note></para>
+  <para style="s1">Ara ratoi Lamatuak Yesus</para>
+  <para style="r">(Mateos 27:57-61; Lukas 23:50-56; Yohanis 19:38-42)</para>
+  <para style="p">
+    <verse number="42-43" style="v" />Basa boe ma hatahori esa sangga dalak fo nakonda Yesus ao-mbaa mamaten numa ai ngganggek naa lain mai. Hatahori naa, nade Yusuf numa kota Arimatea mai, ma hatahori ia oo hatahori esa numa mana maketu-maladi dedeꞌak anggama Yahudi mai boe. Ndia dalen malole. Ma ana nahani taa-taa Manetualain parenda-koasan mai.</para>
+  <para style="p">Yesus fai mamaten naa, ndaa no fai limak. Beꞌe-mai laꞌe-ndaa no hatahori Yahudir fai huhule-haradoin. Huu naa de fai limak naa, Yusuf nau nakonda nakahuluk Yesus ao-mbaa mamaten. De ana tao nambarani dalen fo neu noke Yesus ao-mbaa mamaten nai nggubenor Pilatus. <verse number="44" style="v" />Neu nggubenor namanene Yusuf noke talo naa, boe ma ana heran. De ana nae, “Awii! Hatahori naa mate lai-laik neuk ka. Au duꞌa ae, ta bisa dadi talo naa, oo!”</para>
+  <para style="p">Boe ma nggubenor nadenu hatahorir fo reu roke komedan soldadu naa mai, de natane nae, “Talo bee? Yesus naa, maten ena, do beik?”</para>
+  <para style="p">
+    <verse number="45" style="v" />Komedan soldadu naa naselu nae, “Memak Ana mate numa bebeik kara ia mai ena, Papa.” Nggubenor namanene nala naa, boe ma ana nakaheik Yusuf neu haꞌi nala Yesus ao-mbaa mamaten.</para>
+  <para style="p">
+    <verse number="46" style="v" />De Yusuf neu hasa tema naruk mabeli. Boe ma ana neni Golgotaa neu. Ana nakonda Yesus ao-mbaa mamaten numa ai ngganggek lain mai. Ana oo mboti nalololen nenik tema beuk naa. Faik naa, ara bei fo toꞌi basa rates esa nai lete batu dale. Boe ma ara koꞌo rala Yesus ao-mbaa mamaten, de ralololin neni bolok naa dale neu. Basa de ara loli rala batu bebela moꞌok esa fo ara tatana ralololen neu rates naa lelesun. Boe ma Yusuf asa fali reu sara leo.</para>
+  <para style="p">
+    <verse number="47" style="v" />Faik naa, Maria numa Magdala mai, ma Maria laen (ndia Yoses inan) oo, tungga losa naa boe. Dua sara mete fo rasaneda ratalolole mamanak naa, fo ara tao Yesus ao-mbaa mamaten naa neu.</para>
+  <chapter number="16" style="c" />
+  <para style="s1">Lamatuak Yesus nasoda fali numa mamaten mai!</para>
+  <para style="r">(Mateos 28:1-8; Lukas 24:1-12; Yohanis 20:1-10)</para>
+  <para style="p">
+    <verse number="1" style="v" />Beꞌe-mai fo fai neek, ndia hatahori Yahudir fai huhule-haradoin. Neu ledo tesa ena, Maria numa nusak Magdala mai, Maria esa bali (Yakobis inan) ma Salomi, reu hasa mina kaboo menik fo rae reu bibiru neu Yesus ao-mbaa mamaten, tungga hatahori Yahudir dala-hadan. <verse number="2" style="v" />Neu fai Menggu huhua anan, telu sara reni rates naa reu. <verse number="3-4" style="v" />Neu ara bei laꞌok numa dalak, boe ma rakokola aok rae, “Naa! See ndia bisa tulun ita fo keko heni batu moꞌok naa numa rates lelesun mai? Neu ko ita telu ngga ta tabeꞌi sana, te batu naa moꞌon seli na!”</para>
+  <para style="p">Tehuu neu ara losak ka naa, ara mete-rita batu naa neni loli henik ena. <verse number="5" style="v" />Boe ma ara maso reni rates naa dale reu. Ara nggengger ralan seli, nahuu mete-rita hatahori muri anak esa nanggatuuk nai sira boboa konan, ana pake bua-loꞌa muti manggadilak. <verse number="6" style="v" />Boe ma hatahori muri anak naa nafada sara nae, “Ei hae mamataꞌu! Au bubuluk ei mai sangga Yesus numa Nasaret mai, fo ara rakanisan numa ai ngganggek naa lain. Ana ta nai ia ena, Ana nasoda fali numa mamaten mai ena. Mai fo mete-mita no ei mata heli-helim mara mamanak fo ara tao Yesus ao-mbaa mamaten neuk naa rouk ena. <verse number="7" style="v" />Ei fali lai-lai leo! Miu mafada Petrus asa mae, Yesus nasoda fali numa mamaten mai ena. Ana laꞌo nakahuluk neni Galilea neu ena. Dei fo ara ratonggo ro Yesus nai naa, sama leo nafada ela sara ndia fai bakahulun. De fali miu ngga leo!”<note caller="+" style="x"><char style="xo" closed="false">16:7:</char><char style="xt" closed="false">Mateos 26:32; Markus 14:28</char></note></para>
+  <para style="p">
+    <verse number="8" style="v" />Neu inak kara raa mete-rita mamanak naa rouk, boe ma ara nggengger. De ara ralai dea reu. Basa boe ma ara fali lai-laik. Ara ta rafada esa boe na, neu ara bei numa dalak, nahuu ara ramataꞌu ralan seli.</para>
+  <para style="s1">[Lamatuak Yesus natonggo no Maria numa Magdala mai</para>
+  <para style="r">(Mateos 28:9-10; Yohanis 20:11-18)</para>
+  <para style="p">
+    <verse number="9" style="v" />Fai Menggu huhua anan naa, Yesus neu natudu matan nakahuluk neu Maria numa Magdala mai, fo fai bakahulun Yesus husi nita nitu hitu numa aon mai.<note caller="+" style="f"><char style="fr" closed="false">16:9:</char><char style="ft" closed="false">Susura dedeꞌa Yunani lasin lenak ma neulaun lenak nateꞌe losa kada lanek ka-8. Markus tutuin nateꞌen tungga dalak dua: esa naruk ka (Markus 16:9-20), ma esa kekeꞌuk ka (Markus 16:9-10). Tungga hatahori malelak kara, fo ara bubuluk no malole Markus tutuin ia, tutui mateꞌen kaduak kara iar, ara surak kasa rakahitok. Dua sara tui Yesus nasoda fali numa mamaten mai, ma hatahori fo mana namahere Yesus uen nara.</char></note> <verse number="10" style="v" />Ana mete-nita basa Yesus, boe ma ana fali de nafada basa hatahorir fo fai maneuk kara ara tungga Yesus. Ara bei bua-bua no dale sonak, ma luu-oen nara bei ta mada, rasaneda Yesus mamaten naa. <verse number="11" style="v" />Boe ma Maria nafada sara nae, “Tao hata de ei bei susa? Hae susa bali, te Yesus nasoda fali numa mamaten mai ena! Bebeik kara ia au dei fo atonggo uan!”</para>
+  <para style="p">Tehuu basa sara raselu rae, “Weeh! O kada kokolak lelik!”</para>
+  <para style="s1">Lamatuak Yesus natudu matan neu hatahori dua bali</para>
+  <para style="r">(Lukas 24:13-35)</para>
+  <para style="p">
+    <verse number="12" style="v" />Basa boe ma Yesus ana nunin dua laꞌok reni nggorok esa reu. Neu ara bei laꞌok numa dalak, boe ma Yesus neu natudu matan neu sara. Yesus mata-aon nasafali ena, tehuu ta dook ka, boe ma ara ralelan. <verse number="13" style="v" />Basa boe ma dua sara fali reu rafada nonoon nara rae, “Ei nenene dei! Bebeik kara ia, ai bei fo matonggo mia Yesus numa dalak!”</para>
+  <para style="p">Tehuu nonoon nara basa sara raselu rae, “Heeh! Ei boso kada kokolak lelik talo naa!”</para>
+  <para style="s1">Lamatuak Yesus natudu matan neu basa ana nunin nara</para>
+  <para style="r">(Mateos 28:16-20; Lukas 24:36-49; Yohanis 20:19-23; Nedenuk kara Tutuin 1:6-8)</para>
+  <para style="p">
+    <verse number="14" style="v" />Basa boe ma Yesus natonggo no ana nuni kasalahunu esan nara, neu ara ranggatuuk raꞌa-rinu. Ana nahara neu sara nae, “Weeh! Ei langga batum mara seli! Hatahori rafada ei ena rae, ara mete-rita Au no mata deꞌe heli-helin nara ena, tehuu ei ta nau mamahere! Ei mae, basa sara kada kokolak lelik! Naa! Hatematak ia Au mesa ngga mai ena. Memak Au mate ena, tehuu hatematak ia Au asoda fali numa mamates mai ena! Ei mesa ngga mete no ei matam mara leo.</para>
+  <para style="p">
+    <verse number="15" style="v" />De hatematak ia ei muste laꞌo ndule basa dae-bafok ia, fo miu mafada basa hatahorir laꞌe-neu Au Tutui Maloleng ia.<note caller="+" style="x"><char style="xo" closed="false">16:15:</char><char style="xt" closed="false">Nedenuk kara Tutuin 1:8</char></note> <verse number="16" style="v" />Hatahori fo mana namahere neu Au, ma ana hambu saranik, neu ko Manetualain tao nasoi-nasodan, fo ana leo seku neu no Manetualain nai nusa tetuk do inggu temak. Tehuu hatahori fo mana ta namahere, neu ko ana hambu hukun, ma Manetualain ta simbok kana nai nusa tetuk do inggu temak, de ana leo kada dea seku neu. <verse number="17" style="v" />Ma hatahorir fo mana ramahere neu Au, ara bisa tao tanda heran mata-matak kara, fo basa hatahorir bubuluk rae, sira koasan naa memak numa Manetualain mai. Haꞌi netuduk, neu ko ara bisa husi nitur pake Au nadeng. Neu ko Manetualain fee sara bisa kokolak pake dedeꞌak laen, leo mae ara ta bei ralela dedeꞌak naa. <verse number="18" style="v" />Ma leo mae ara toꞌu mengge karasok, do, ara rinu hambu raso, ara ta hambu sosoek. Boe ma mete ma ara ndae liman nara reu hatahori hedis sara langgan, neu ko ara hai.”</para>
+  <para style="s1">Lamatuak Yesus hene neni nusa tetuk do inggu temak neu</para>
+  <para style="r">(Lukas 24:50-53; Nedenuk kara Tutuin 1:9-11)</para>
+  <para style="p">
+    <verse number="19" style="v" />Yesus kokolak basa no ana nunin nara, boe ma Manetualain soꞌu botik kana hene neni nusa tetuk do inggu temak neu. Nai naa, Yesus dadi neu Manetualain lima konan, fo Dua Sara ranggatuuk toꞌu parenda sama-sama.<note caller="+" style="x"><char style="xo" closed="false">16:19:</char><char style="xt" closed="false">Nedenuk kara Tutuin 1:9-11</char></note></para>
+  <para style="p">
+    <verse number="20" style="v" />Basa boe ma ana nunin nara tungga Ndia parendan. De ara sudi bee reu fo tui-bengga neu basa hatahorir laꞌe-neu Yesus Tutui Malolen. Boe ma Manetualain fee sara koasa fo ara tao basa tanda heran nara fo Yesus nafada elak kara raa. De hatahori noꞌuk ka ramahere neu Yesus, te ara bubuluk ena rae, Tutui Malole naa, memak tebe.]</para>
+  <para style="s1">[MARKUS NATEꞌE TUTUIN TUNGGA SUSURA LELE ULUK LAEN NARA</para>
+  <para style="p">
+    <char style="vp">9</char> Neu ina kateluk kara raa losa Petrus asa ena, boe ma ara rafada basa-basan laꞌe-neu hatahori muri anak naa, fo mana kokolak numa rates ndia bebeik kara raa.<note caller="+" style="f"><char style="fr" closed="false">16:20:</char><char style="ft" closed="false">Susura dedeꞌa Yunani lasin lenak ma neulaun lenak nateꞌe losa kada lanek ka-8. Markus tutuin nateꞌen tungga dalak dua: esa naruk ka (Markus 16:9-20), ma esa kekeꞌuk ka (Markus 16:9-10). Tungga hatahori malelak kara, fo ara bubuluk no malole Markus tutuin ia, tutui mateꞌen kaduak kara iar, ara surak kasa rakahitok. Dua sara tui Yesus nasoda fali numa mamaten mai, ma hatahori fo mana namahere Yesus uen nara.</char></note> <char style="vp">10</char> Basa boe ma Yesus parenda ana nunin nara fo reu tui-bengga laꞌe-neu Ndia Tutui Malolen ia nai basa mamanak kara losa dae-bafok buꞌun nara. Tutui Malole ia natudu dalak fo Manetualain tao nasoi-nasoda hatahorir numa sala-singgon nara mai fo rasoda seku neu ro Ndia.</para>
+  <para style="p">Tutui Malole ia, memak tetebe ndoos. Huu naa de ana nakatataka nakandoo losa ta namaketu.]</para>
+</usx>

--- a/tests/gqlquery_verses_by_usx.test.js
+++ b/tests/gqlquery_verses_by_usx.test.js
@@ -51,6 +51,15 @@ const versesTest6 = [
   { verseRange: "21", text: "chapter 6 test 21" },
 ];
 
+const versesTest7 = [
+  { verseRange: "1", text: "chapter 7 test 1" },
+  { verseRange: "2", text: "chapter 7 test 2" },
+  { verseRange: "3", text: "chapter 7 test 3" },
+  { verseRange: "4", text: "chapter 7 test 4" },
+  { verseRange: "5-6a", text: "chapter 7 test 5-6a" },
+  { verseRange: "6b", text: "chapter 7 test 6b" },
+];
+
 const usxJsonTest = {
   bookCode: "bookCodeTest",
   chapters: [
@@ -176,4 +185,33 @@ test("Missed Verse Range diff > 1 test", function (t) {
 
   t.equal(rangeVerseSequence, 4);
   t.equal(rangeVerseText, "chapter 6 test 4-20");
+});
+
+test("Same verse number but with different sub-category a and b", function (t) {
+  t.plan(5);
+
+  const usxJsonTesTemp = {
+    bookCode: "bookCodeTest",
+    chapters: [
+      { verses: versesTest1, chapter: 1 },
+      { verses: versesTest7, chapter: 2 },
+    ],
+  };
+
+  const verseRow = populateDBHandler.getVersesToInsert(usxJsonTesTemp);
+  const lastIndex = verseRow.length - 1;
+
+  t.equal(verseRow.length, 12);
+
+  const lastVerseSequence = verseRow[lastIndex][1];
+  const lastVerseText = verseRow[lastIndex][2];
+
+  t.equal(lastVerseSequence, 6);
+  t.equal(lastVerseText, "chapter 7 test 6b");
+
+  const rangeVerseSequence = verseRow[lastIndex - 1][1];
+  const rangeVerseText = verseRow[lastIndex - 1][2];
+
+  t.equal(rangeVerseSequence, 5);
+  t.equal(rangeVerseText, "chapter 7 test 5-6a");
 });


### PR DESCRIPTION
## Description
The handler that generates verses and stores them in the SQLite database has been modified to support the scenario where a chapter contains multiple verses with the same number but different categories (e.g. 6a and 6b). Previously, only the first verse was stored.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-515

## How Do I QA This
- You should run the following tests and they pass:
- You should run the following tests and they pass:
```
node tests/gqlquery_verses_by_usx.test.js
```
- outcome
```
TAP version 13
# Verse Rows From Chapters test
ok 1 should be strictly equal
ok 2 should be strictly equal
ok 3 should be strictly equal
# Verse Rows To Insert
ok 4 should be strictly equal
ok 5 should be strictly equal
ok 6 should be strictly equal
# Missed Verse test
ok 7 should be strictly equal
# Missed Range Verse diff = 1 test
ok 8 should be strictly equal
ok 9 should be strictly equal
ok 10 should be strictly equal
ok 11 should be strictly equal
ok 12 should be strictly equal
# Missed Verse Range diff > 1 test
ok 13 should be strictly equal
ok 14 should be strictly equal
ok 15 should be strictly equal
ok 16 should be strictly equal
ok 17 should be strictly equal
# Same verse number but with different sub-category a and b
ok 18 should be strictly equal
ok 19 should be strictly equal
ok 20 should be strictly equal
ok 21 should be strictly equal
ok 22 should be strictly equal

1..22
# tests 22
# pass  22

# ok
```
- Also, you can run the following command and they should return success:
```
node biblebrain_uploader.js run test/input/TXQWYIN1ET/ --populate-db=./output/TXQWYIN1ET-db/TXQWYIN_ET.db --generate-json=./output/TXQWYIN_ET-json
```

- Outcome
```
Generate JSON => Generate JSON filese - Start process..
Populate DB - Start process..
Populate DB => Complete:  Markus
Populate DB => success
Generate JSON => File list (1) processing completed
Generate JSON => Complete USX File: test/input/TXQWYIN1ET/041MRK.usx
load verses success, rowcount 634
load tableContents success, rowcount 1

```
